### PR TITLE
Restructure audiovisual file data structure for UUIDs

### DIFF
--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -1,37 +1,42 @@
-import { SelectInput, TextInput, TimeInput } from "@components/Formic/index.tsx";
-import type { Event, Translations } from "@ty/Types.ts";
-import { FieldArray, Form, Formik, useFormikContext } from "formik";
-import * as Separator from "@radix-ui/react-separator";
-import type React from "react";
-import { Button } from "@radix-ui/themes";
-import { PlusIcon, TrashIcon } from "@radix-ui/react-icons";
-import './EventForm.css'
-import { BottomBar } from "@components/BottomBar/BottomBar.tsx";
-import { RichTextInput } from "@components/Formic/index.tsx";
-import { defaultEvent } from "@lib/events/index.ts";
+import {
+  SelectInput,
+  TextInput,
+  TimeInput,
+} from '@components/Formic/index.tsx';
+import type { FormEvent, Translations } from '@ty/Types.ts';
+import { FieldArray, Form, Formik, useFormikContext } from 'formik';
+import * as Separator from '@radix-ui/react-separator';
+import type React from 'react';
+import { Button } from '@radix-ui/themes';
+import { PlusIcon, TrashIcon } from '@radix-ui/react-icons';
+import './EventForm.css';
+import { BottomBar } from '@components/BottomBar/BottomBar.tsx';
+import { RichTextInput } from '@components/Formic/index.tsx';
+import { generateDefaultEvent } from '@lib/events/index.ts';
+import { v4 as uuidv4 } from 'uuid';
 
 interface Props {
   children?: React.ReactNode;
-  event?: Event;
+  event?: FormEvent;
   i18n: Translations;
-  onSubmit: (data: Event) => any;
-  styles?: { [key: string]: any }
+  onSubmit: (data: FormEvent) => any;
+  styles?: { [key: string]: any };
 }
 
 const initialAvFile = {
   label: '',
   file_url: '',
-  duration: 0
-}
+  duration: 0,
+};
 
 export const EventForm: React.FC<Props> = (props) => (
   <Formik
-    initialValues={props.event || defaultEvent}
+    initialValues={props.event || generateDefaultEvent()}
     onSubmit={props.onSubmit}
   >
     <FormContents {...props} />
   </Formik>
-)
+);
 
 const FormContents: React.FC<Props> = ({ children, i18n, styles }) => {
   const { t } = i18n;
@@ -39,104 +44,104 @@ const FormContents: React.FC<Props> = ({ children, i18n, styles }) => {
   const { setFieldValue, values, isSubmitting } = useFormikContext();
 
   return (
-    <Form className="event-form" style={styles}>
-      <div className="form-body">
+    <Form className='event-form' style={styles}>
+      <div className='form-body'>
         <h2>{t['Event Information']}</h2>
-        <TextInput
-          label={t['Label']}
-          name='label'
-          required
-        />
+        <TextInput label={t['Label']} name='label' required />
         <SelectInput
           label={t['Item Type']}
           name='item_type'
           options={[
             {
               label: t['Audio'],
-              value: 'Audio'
+              value: 'Audio',
             },
             {
               label: t['Video'],
-              value: 'Video'
-            }
+              value: 'Video',
+            },
           ]}
           required
         />
-        <Separator.Root
-          className="SeparatorRoot"
-          decorative
-        />
+        <Separator.Root className='SeparatorRoot' decorative />
         <h2>{t['Audiovisual File(s)']}</h2>
         <FieldArray
           name='audiovisual_files'
-          render={(arrayHelpers) => (
-            <div className="av-files-list">
-              {(values as Event).audiovisual_files.map((_av, idx) => (
-                <div key={idx} className="av-files-fields">
-                  <TextInput
-                    className="av-label-input"
-                    label={idx === 0 ? t['Label'] : undefined}
-                    name={`audiovisual_files.${idx}.label`}
-                  />
-                  <TextInput
-                    className="av-file-url-input"
-                    label={idx === 0 ? t['File URL'] : undefined}
-                    name={`audiovisual_files.${idx}.file_url`}
-                  />
-                  <TimeInput
-                    className="av-duration-input"
-                    label={idx === 0 ? t['Duration'] : undefined}
-                    onChange={(input: number) => (
-                      setFieldValue(`audiovisual_files.${idx}.duration`, input)
-                    )}
-                    defaultValue={(values as Event).audiovisual_files[idx].duration}
-                  />
-                  {idx !== 0
-                    ? (
+          render={() => (
+            <div className='av-files-list'>
+              {Object.keys((values as FormEvent).audiovisual_files).map(
+                (key, idx) => (
+                  <div key={key} className='av-files-fields'>
+                    <TextInput
+                      className='av-label-input'
+                      label={idx === 0 ? t['Label'] : undefined}
+                      name={`audiovisual_files.${key}.label`}
+                    />
+                    <TextInput
+                      className='av-file-url-input'
+                      label={idx === 0 ? t['File URL'] : undefined}
+                      name={`audiovisual_files.${key}.file_url`}
+                    />
+                    <TimeInput
+                      className='av-duration-input'
+                      label={idx === 0 ? t['Duration'] : undefined}
+                      onChange={(input: number) =>
+                        setFieldValue(
+                          `audiovisual_files.${key}.duration`,
+                          input
+                        )
+                      }
+                      defaultValue={
+                        (values as FormEvent).audiovisual_files[key].duration
+                      }
+                    />
+                    {idx !== 0 ? (
                       <Button
-                        className="av-trash-button"
-                        onClick={() => arrayHelpers.remove(idx)}
+                        className='av-trash-button'
+                        onClick={() => {
+                          setFieldValue(`audiovisual_files.${key}`, undefined);
+                        }}
+                        type='button'
                         variant='ghost'
                       >
                         <TrashIcon />
                       </Button>
+                    ) : (
                       // show an empty div so the spacing stays consistent
-                    ) : <div className="av-trash-button"></div>}
-                </div>
-              ))}
+                      <div className='av-trash-button'></div>
+                    )}
+                  </div>
+                )
+              )}
               <Button
-                className="primary add-av-button"
-                onClick={() => arrayHelpers.push(initialAvFile)}
+                className='primary add-av-button'
+                onClick={() =>
+                  setFieldValue(`audiovisual_files.${uuidv4()}`, initialAvFile)
+                }
                 type='button'
               >
-                <PlusIcon color="white" />
+                <PlusIcon color='white' />
                 {t['Add']}
               </Button>
             </div>
           )}
         />
-        <Separator.Root
-          className="SeparatorRoot"
-          decorative
-        />
+        <Separator.Root className='SeparatorRoot' decorative />
         <h2>{t['Other']}</h2>
         <RichTextInput
           label={t['Description (Optional)']}
           helperText={t['A brief paragraph describing your event.']}
           name='description'
-          initialValue={(values as Event).description}
-          onChange={data => setFieldValue('description', data)}
+          initialValue={(values as FormEvent).description}
+          onChange={(data) => setFieldValue('description', data)}
         />
-        <TextInput
-          label={t['Citation (Optional)']}
-          name='citation'
-        />
+        <TextInput label={t['Citation (Optional)']} name='citation' />
         {children}
       </div>
       <BottomBar>
-        <div className="bottom-bar-flex">
+        <div className='bottom-bar-flex'>
           <Button
-            className="cancel-button outline"
+            className='cancel-button outline'
             onClick={() => history.back()}
             type='button'
             variant='outline'
@@ -144,7 +149,7 @@ const FormContents: React.FC<Props> = ({ children, i18n, styles }) => {
             {t['cancel']}
           </Button>
           <Button
-            className="save-button primary"
+            className='save-button primary'
             disabled={isSubmitting}
             type='submit'
           >
@@ -153,5 +158,5 @@ const FormContents: React.FC<Props> = ({ children, i18n, styles }) => {
         </div>
       </BottomBar>
     </Form>
-  )
-}
+  );
+};

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -1,20 +1,17 @@
-import type { Event } from '@ty/Types.ts';
+import type { FormEvent } from '@ty/Types.ts';
+import { v4 as uuidv4 } from 'uuid';
 
-export const defaultEvent: Event = {
-  audiovisual_files: [
-    {
+export const generateDefaultEvent = (): FormEvent => ({
+  audiovisual_files: {
+    [uuidv4()]: {
       label: '',
       file_url: '',
       duration: 90,
-    },
-  ],
+    }
+  },
   auto_generate_web_page: true,
   description: [],
   citation: '',
-  created_at: '',
-  created_by: '',
   item_type: 'Audio',
   label: '',
-  updated_at: '',
-  updated_by: '',
-};
+})

--- a/src/lib/parse/index.ts
+++ b/src/lib/parse/index.ts
@@ -1,11 +1,10 @@
 import type {
   AnnotationEntry,
-  Event,
-  NewEvent,
+  FormEvent,
   ParseAnnotationResults,
-  UserInfo,
 } from '@ty/Types.ts';
 import { read, utils } from 'xlsx';
+import { v4 as uuidv4 } from 'uuid';
 
 export const parseSpreadsheetData = async (
   data: File,
@@ -54,15 +53,15 @@ export const mapEventData = (
   data: any[],
   map: { [key: string]: number },
   autoGenerateWebpage: boolean
-): NewEvent[] => {
+): FormEvent[] => {
   return data.map((item) => ({
-    audiovisual_files: [
-      {
+    audiovisual_files: {
+      [uuidv4()]: {
         label: item[map['audiovisual_file_label']],
         file_url: item[map['audiovisual_file_url']],
         duration: item[map['audiovisual_file_duration']],
       },
-    ],
+    },
     auto_generate_web_page: autoGenerateWebpage,
     citation: item[map['citation']],
     item_type: item[map['item_type']],

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -70,12 +70,14 @@ export type Publish = {
   publishISODate: string;
 };
 
+export type AudiovisualFile = {
+  label: string;
+  file_url: string;
+  duration: number;
+}
+
 export type Event = {
-  audiovisual_files: {
-    label: string;
-    file_url: string;
-    duration: number;
-  }[];
+  audiovisual_files: { [key: string]: AudiovisualFile };
   auto_generate_web_page: boolean;
   description: Node[];
   citation?: string;
@@ -87,7 +89,7 @@ export type Event = {
   updated_by: string;
 };
 
-export interface NewEvent
+export interface FormEvent
   extends Omit<
     Event,
     'created_at' | 'created_by' | 'updated_at' | 'updated_by'


### PR DESCRIPTION
# Summary

- changes the format of the `audiovisual_files` array in event objects to an object with UUIDs as keys (see below)
- updates the `EventForm` and a couple other places to work with the new structure

# Example

## Old format

```ts
type Event = {
  audiovisual_files: {
    label: string;
    file_url: string;
    duration: number;
  }[]
  // ...
}
```

# New format

```ts
type Event = {
    audiovisual_files: {
      [key: string]: {
        label: string;
        file_url: string;
        duration: number
      }
    }
  // ...
}
```