### PR TITLE
Remove Slate plugin that prevented event embed deletion

### DIFF
--- a/src/backend/projectHelpers.ts
+++ b/src/backend/projectHelpers.ts
@@ -82,7 +82,7 @@ export const getPageData = (fs: IFs, topLevelNames: string[], dir: string) => {
   // Fill two separate arrays depending on whether a
   // page is a child or a parent.
   for (const filename of topLevelNames) {
-    if (filename !== 'order.json') {
+    if (filename !== 'order.json' && filename !== '.gitkeep') {
       const contents: Page = JSON.parse(
         fs.readFileSync(`/data/${dir}/${filename}`) as string
       );

--- a/src/components/Formic/SlateInput/SlateInput.tsx
+++ b/src/components/Formic/SlateInput/SlateInput.tsx
@@ -308,29 +308,6 @@ const insertImage = (editor: BaseEditor & ReactEditor, image: ImageData) => {
   Transforms.insertNodes(editor, nodes);
 };
 
-// Complex/rich elements that the user shouldn't be able to accidentally
-// delete by backspacing.
-const NO_BACKSPACE_DELETE = ['grid', 'event', 'event-comparison'];
-
-const withPreventBlockDeletion = (editor: Editor) => {
-  const { apply } = editor;
-
-  editor.apply = (operation) => {
-    console.log(operation);
-    if (
-      operation.type === 'remove_node' &&
-      NO_BACKSPACE_DELETE.includes(operation.node.type)
-    ) {
-      return;
-    }
-
-    // Other cases
-    apply(operation);
-  };
-
-  return editor;
-};
-
 interface Props {
   initialValue?: any;
   onChange: (data: any) => any;
@@ -340,10 +317,7 @@ interface Props {
 }
 
 export const SlateInput: React.FC<Props> = (props) => {
-  const editor = useMemo(
-    () => withReact(withPreventBlockDeletion(createEditor())),
-    []
-  );
+  const editor = useMemo(() => withReact(createEditor()), []);
   const renderElement = useCallback(
     (elProps: any) => (
       <Element {...elProps} project={props.project} i18n={props.i18n} />


### PR DESCRIPTION
# Summary

In my original page form PR, I included a `withPreventBlockDeletion` plugin to the Slate editor to prevent users from being able to accidentally delete event embeds when hitting backspace. Unfortunately, Slate's editor events don't differentiate between backspace deletion and manual deletion (i.e. clicking the Delete button in the meatball menu). So this plugin had the effect of making it impossible to delete event embeds.

This PR removes the plugin. It also updates the page-fetching helper code to accommodate the new `.gitkeep` file that we've started using in the project template.