### PR TITLE
Update props and default values for event form

### DIFF
--- a/src/components/EventForm/EventForm.tsx
+++ b/src/components/EventForm/EventForm.tsx
@@ -91,7 +91,7 @@ const FormContents: React.FC<Props> = ({ children, i18n, styles }) => {
                           input
                         )
                       }
-                      defaultValue={
+                      initialValue={
                         (values as FormEvent).audiovisual_files[key].duration
                       }
                     />
@@ -134,7 +134,6 @@ const FormContents: React.FC<Props> = ({ children, i18n, styles }) => {
           name='description'
           i18n={i18n}
           initialValue={(values as FormEvent).description}
-          onChange={(data) => setFieldValue('description', data)}
         />
         <TextInput label={t['Citation (Optional)']} name='citation' />
         {children}

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -7,11 +7,20 @@ export const generateDefaultEvent = (): FormEvent => ({
       label: '',
       file_url: '',
       duration: 90,
-    }
+    },
   },
   auto_generate_web_page: true,
-  description: [],
+  description: [
+    {
+      type: 'paragraph',
+      children: [
+        {
+          text: '',
+        },
+      ],
+    },
+  ],
   citation: '',
   item_type: 'Audio',
   label: '',
-})
+});


### PR DESCRIPTION
# Summary

It seems like we all forgot that this component existed some time ago. It needed two changes to account for changes we've made in the codebase since it was created.

* change `defaultValue` prop to `initialValue` when it uses `TimeInput`
  * this prop was renamed at some point and the lack of an `initialValue` was causing the edit form to crash
* update the initial value for `description` to include an empty Slate paragraph
  * the previous default of an empty array (`[]`) caused Slate to crash, as it expects at least one node to always exist