### PR TITLE
Multiple AV files in Event Detail

### DIFF
--- a/src/apps/EventDetail/EventDetail.css
+++ b/src/apps/EventDetail/EventDetail.css
@@ -13,6 +13,22 @@
   z-index: 100;
 }
 
+.event-detail .av-file-selection {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.event-detail .av-file-selection .select-trigger {
+  box-shadow: none;
+  width: auto;
+}
+
+.event-detail .av-file-selection .av-file-label {
+  font-weight: 600;
+}
+
 .event-detail .event-detail-label {
   display: flex;
   align-items: center;
@@ -170,6 +186,11 @@
   left: -30px;
   height: 16px;
   width: 16px;
+}
+
+.event-detail .empty-annos-note {
+  text-align: center;
+  width: 100%;
 }
 
 .event-detail .rt-TableColumnHeaderCell {

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -34,5 +34,7 @@
   "Copy timestamp": "Copy timestamp",
   "Timestamp": "Timestamp",
   "Are you sure you want to delete this event?": "Are you sure you want to delete this event?",
-  "associated annotations will also be deleted.": "associated annotations will also be deleted."
+  "associated annotations will also be deleted.": "associated annotations will also be deleted.",
+  "AV File": "AV File",
+  "No annotations have been added.": "No annotations have been added."
 }


### PR DESCRIPTION
# Summary

- adds a new state item, `avFile`, to the Event Detail component to track which audiovisual file is currently playing
- adds a select menu for the user to switch between AV files
- hides the select menu (i.e. keeps behavior unchanged) when only one AV file is selected
- adds a note to the table to indicate when there are no annotations for a given AV file

# Screen recording


https://github.com/user-attachments/assets/cd5d0894-140c-418a-a728-36bb7ea630a2

