### PR TITLE
Annotation set features

### DIFF
--- a/src/apps/EventDetail/AnnotationTable.tsx
+++ b/src/apps/EventDetail/AnnotationTable.tsx
@@ -1,0 +1,214 @@
+import { MeatballMenu } from '@components/MeatballMenu/index.ts';
+import { formatTimestamp } from '@lib/events/index.ts';
+import { serialize } from '@lib/slate/index.tsx';
+import { Pencil2Icon } from '@radix-ui/react-icons';
+import { Table } from '@radix-ui/themes';
+import type {
+  AnnotationEntry,
+  ProjectData,
+  Tag,
+  Translations,
+} from '@ty/Types.ts';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Trash } from 'react-bootstrap-icons';
+
+const formatTimestamps = (start: number, end: number) =>
+  `${formatTimestamp(start, false)} - ${formatTimestamp(end, false)}`;
+
+interface TagListProps {
+  groups: {
+    [key: string]: string;
+  };
+  maxWidth: number;
+  tags: Tag[];
+}
+
+const TagList: React.FC<TagListProps> = (props) => {
+  // the last tag to display in the list before truncating
+  const [displayIdx, setDisplayIdx] = useState(0);
+
+  const tagCellEl = useRef<HTMLDivElement>(null);
+  const tagHolderEl = useRef<HTMLDivElement>(null);
+
+  const tagComponents = useMemo(
+    () =>
+      props.tags.map((t, idx) => {
+        return (
+          <div
+            className='tag-item'
+            key={idx}
+            style={{
+              backgroundColor:
+                props.groups[
+                  t.category.toLowerCase() as keyof typeof props.groups
+                ],
+            }}
+          >
+            <span className='tag-content'>{t.tag}</span>
+          </div>
+        );
+      }),
+    [props.tags, props.groups]
+  );
+
+  useEffect(() => {
+    if (!tagCellEl.current || !tagHolderEl.current) {
+      return;
+    }
+
+    let widthTracker = 0;
+
+    const tagEls = tagHolderEl.current.querySelectorAll('.tag-item');
+
+    for (let i = 0; i < tagEls.length; i++) {
+      // if we've made it to the last one, that means we
+      // can show all the tags!
+      if (i === tagEls.length - 1) {
+        setDisplayIdx(i);
+        break;
+        // stop if the current tag would overflow the cell
+      } else if (widthTracker + tagEls[i].clientWidth > props.maxWidth) {
+        setDisplayIdx(i);
+        break;
+      } else {
+        // account for the gap and margin
+        widthTracker += tagEls[i].clientWidth + 30;
+      }
+    }
+  }, [tagCellEl.current, tagHolderEl.current, props.maxWidth]);
+
+  return (
+    <>
+      {/* use an invisible div to render all the tags in order to get their widths */}
+      <div className='invisible-tag-holder' ref={tagHolderEl}>
+        {tagComponents}
+      </div>
+      {/* then display them for real here */}
+      <div className='tag-cell-container' ref={tagCellEl}>
+        {tagComponents.slice(0, displayIdx + 1)}
+        {displayIdx !== tagComponents.length - 1 && (
+          <div className='tag-cell-overflow'>
+            &#43;{tagComponents.length - displayIdx - 1}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+interface AnnotationTableProps {
+  i18n: Translations;
+  displayAnnotations: AnnotationEntry[];
+  project: ProjectData;
+  setDeleteAnnoUuid: (uuid: string) => void;
+  setEditAnnoUuid: (uuid: string) => void;
+  setAnnoPosition: (pos: number) => void;
+}
+
+export const AnnotationTable: React.FC<AnnotationTableProps> = (props) => {
+  const [tagCellWidth, setTagCellWidth] = useState(0);
+
+  const { t } = props.i18n;
+
+  const tagGroups = useMemo(() => {
+    const obj: { [key: string]: string } = {};
+
+    props.project.project.tags.tagGroups.forEach(
+      (tg) => (obj[tg.category.toLowerCase()] = tg.color)
+    );
+
+    return obj;
+  }, [props.project]);
+
+  const tagHeaderCell = useRef<HTMLTableCellElement>(null);
+
+  useEffect(() => {
+    if (!tagHeaderCell.current) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      // allow for margins and for the + overflow icon on the right
+      setTagCellWidth(entries[0].target.clientWidth - 170);
+    });
+    resizeObserver.observe(tagHeaderCell.current);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return (
+    <div className='event-detail-table-container'>
+      <Table.Root>
+        <Table.Header>
+          <Table.Row className='header-row'>
+            <Table.ColumnHeaderCell className='timestamp-column'>
+              <div className='header-cell-container'>{t['Timestamp']}</div>
+            </Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell className='text-column'>
+              <div className='header-cell-container'>{t['Text']}</div>
+            </Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell
+              className='tags-header-cell tags-column'
+              ref={tagHeaderCell}
+            >
+              <div className='header-cell-container'>{t['Tags']}</div>
+            </Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell className='options-header-cell options-column'></Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {props.displayAnnotations.length === 0 && (
+            <Table.Row>
+              <Table.Cell colSpan={4} className='empty-annos-note'>
+                <p>{t['No annotations have been added.']}</p>
+              </Table.Cell>
+            </Table.Row>
+          )}
+          {props.displayAnnotations.map((an) => (
+            <Table.Row className='annotation-table-row' key={an.uuid}>
+              <Table.Cell
+                className='annotation-data-cell timestamp-cell'
+                onClick={() => props.setAnnoPosition(an.start_time)}
+              >
+                <p>{formatTimestamps(an.start_time, an.end_time)}</p>
+              </Table.Cell>
+              <Table.Cell
+                className='annotation-data-cell annotation-cell'
+                onClick={() => props.setAnnoPosition(an.start_time)}
+              >
+                {serialize(an.annotation)}
+              </Table.Cell>
+              <Table.Cell
+                className='annotation-data-cell tag-cell'
+                onClick={() => props.setAnnoPosition(an.start_time)}
+              >
+                {tagCellWidth && (
+                  <TagList
+                    groups={tagGroups}
+                    maxWidth={tagCellWidth}
+                    tags={an.tags}
+                  />
+                )}
+              </Table.Cell>
+              <Table.Cell className='meatball-cell'>
+                <div className='meatball-container'>
+                  <MeatballMenu
+                    buttons={[
+                      {
+                        label: t['Edit'],
+                        icon: Pencil2Icon,
+                        onClick: () => props.setEditAnnoUuid(an.uuid),
+                      },
+                      {
+                        label: t['Delete'],
+                        icon: Trash,
+                        onClick: () => props.setDeleteAnnoUuid(an.uuid),
+                      },
+                    ]}
+                    row={t}
+                  />
+                </div>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </div>
+  );
+};

--- a/src/apps/EventDetail/AvFilePicker.tsx
+++ b/src/apps/EventDetail/AvFilePicker.tsx
@@ -1,0 +1,43 @@
+import { formatTimestamp } from '@lib/events/index.ts';
+import { ChevronDownIcon } from '@radix-ui/react-icons';
+import * as Select from '@radix-ui/react-select';
+import type { Event } from '@ty/Types.ts';
+
+interface Props {
+  event: Event;
+  onChange: (arg: string) => any;
+  value: string;
+}
+
+export const AvFilePicker: React.FC<Props> = (props) => {
+  return (
+    <Select.Root onValueChange={props.onChange} value={props.value}>
+      <Select.Trigger className='select-trigger'>
+        <Select.Value className='select-value' />
+        <Select.Icon className='select-icon'>
+          <ChevronDownIcon />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content className='select-content' position='popper'>
+          <Select.Viewport className='select-viewport'>
+            {Object.keys(props.event.audiovisual_files).map((uuid, idx) => (
+              <Select.Item className='select-item' key={uuid} value={uuid}>
+                <Select.ItemText className='select-item-text'>
+                  {idx + 1}.&nbsp;
+                  {props.event.audiovisual_files[uuid].label}&nbsp; (
+                  {formatTimestamp(
+                    props.event.audiovisual_files[uuid].duration,
+                    false
+                  )}
+                  )
+                </Select.ItemText>
+                <Select.ItemIndicator className='select-indicator'></Select.ItemIndicator>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+};

--- a/src/apps/EventDetail/EventDetail.css
+++ b/src/apps/EventDetail/EventDetail.css
@@ -9,6 +9,24 @@
   padding-bottom: 60px;
 }
 
+.event-detail .set-info-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.event-detail .set-info-bar .set-info-bar-right {
+  display: flex;
+  gap: 8px;
+  width: 60%;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.event-detail .add-set-button svg {
+  margin: 0;
+}
+
 .delete-confirmation-dialog {
   z-index: 100;
 }
@@ -81,7 +99,7 @@
   display: block;
   z-index: 2;
   background-color: var(--gray-100);
-  padding: 10px 0;
+  padding-top: 10px;
 }
 
 .csv-button,
@@ -116,8 +134,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 38px;
-  margin: 10px 0;
+  height: 58px;
+  padding: 0 16px;
+  background: #fff;
+  border: 1px solid var(--gray-200);
 }
 
 .event-detail .annotation-table-row:hover {
@@ -157,10 +177,21 @@
   gap: 12px;
 }
 
-.event-detail .tag-cell-container {
+.event-detail .tag-cell-container,
+.event-detail .invisible-tag-holder {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.event-detail .tag-cell-container .tag-cell-overflow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  background: var(--gray-200);
+  padding: 4px 10px;
+  font-weight: 700;
 }
 
 .event-detail .tag-item {
@@ -193,9 +224,12 @@
   width: 100%;
 }
 
-.event-detail .rt-TableColumnHeaderCell {
+.event-detail .header-row .rt-TableColumnHeaderCell {
   padding: 0;
   height: 32px;
+  background: var(--gray-200);
+  border-left: 1px solid #fff;
+  border-right: 1px solid #fff;
 }
 
 .event-detail .rt-TableColumnHeaderCell .header-cell-container {
@@ -203,14 +237,6 @@
   align-items: center;
   height: 100%;
   margin: 0 10px;
-}
-
-.event-detail .options-header-cell {
-  border-left: none !important;
-}
-
-.event-detail .tags-header-cell {
-  border-right: none !important;
 }
 
 .event-detail .rt-TableColumnHeaderCell {
@@ -229,4 +255,10 @@
 
 .event-detail .timestamp-cell {
   white-space: nowrap;
+}
+
+.invisible-tag-holder {
+  position: absolute;
+  z-index: -1;
+  opacity: 0;
 }

--- a/src/apps/EventDetail/SetSelect.tsx
+++ b/src/apps/EventDetail/SetSelect.tsx
@@ -1,0 +1,53 @@
+import { ChevronDownIcon } from '@radix-ui/react-icons';
+import * as Select from '@radix-ui/react-select';
+import { useMemo } from 'react';
+
+interface Props {
+  onChange: (arg: string) => any;
+  sets: {
+    label: string;
+    uuid: string;
+  }[];
+  value: {
+    label: string;
+    uuid: string;
+  };
+}
+
+const truncate = (str: string) =>
+  str.length > 76 ? `${str.substring(0, 76)}...` : str;
+
+export const SetSelect: React.FC<Props> = (props) => {
+  const truncatedSets = useMemo(() => {
+    return props.sets.map((set) => ({
+      label: truncate(set.label),
+      uuid: set.uuid,
+    }));
+  }, [props.sets]);
+
+  return (
+    <Select.Root onValueChange={props.onChange} value={props.value.uuid}>
+      <Select.Trigger className='select-trigger'>
+        <Select.Value>{truncate(props.value.label)}</Select.Value>
+        <Select.Icon className='select-icon'>
+          <ChevronDownIcon />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content className='select-content' position='popper'>
+          <Select.Viewport className='select-viewport'>
+            {truncatedSets.map((set) => (
+              <Select.Item
+                className='select-item'
+                key={set.uuid}
+                value={set.uuid}
+              >
+                <p>{set.label}</p>
+              </Select.Item>
+            ))}
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+};

--- a/src/components/AnnotationModal/AnnotationModal.tsx
+++ b/src/components/AnnotationModal/AnnotationModal.tsx
@@ -2,11 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { Formik, useFormikContext } from 'formik';
 import { generateDefaultAnnotation } from '@lib/events/index.ts';
 import type { AnnotationEntry, ProjectData, Translations } from '@ty/Types.ts';
-import {
-  RichTextInput,
-  SelectInput,
-  TimeInput,
-} from '@components/Formic/index.tsx';
+import { RichTextInput, TimeInput } from '@components/Formic/index.tsx';
 import { Button } from '@radix-ui/themes';
 import './AnnotationModal.css';
 import { TagSelect } from './TagSelect.tsx';
@@ -24,7 +20,9 @@ interface Props {
 
 export const AnnotationModal: React.FC<Props> = (props) => (
   <Formik
-    initialValues={props.annotation || generateDefaultAnnotation()}
+    initialValues={
+      props.annotation || (generateDefaultAnnotation() as AnnotationEntry)
+    }
     onSubmit={props.onSubmit}
   >
     <AnnotationModalContents {...props} />
@@ -66,13 +64,6 @@ export const AnnotationModalContents: React.FC<Props> = (props) => {
                 name='annotation'
                 elementTypes={['blocks', 'marks']}
               />
-              {/* <SelectInput
-              label={t['Annotation Set']}
-              // todo: I think we're using some sort of tag-based system for sets,
-              //       not a separate field.
-              name='annotation_set'
-              options={[]}
-            /> */}
               <div>
                 <div className='av-label-bold formic-form-label'>
                   {t['Tags']}

--- a/src/components/Formic/Formic.css
+++ b/src/components/Formic/Formic.css
@@ -281,6 +281,8 @@
   gap: 5px;
   background-color: white;
   color: var(--gray-900);
+  box-shadow: none;
+  text-align: left;
 }
 
 .select-trigger:hover {
@@ -301,7 +303,8 @@
   border-radius: 6px;
   box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35),
     0px 10px 20px -15px rgba(22, 23, 24, 0.2);
-  width: 100%;
+  text-align: left;
+  width: var(--radix-select-trigger-width);
 }
 
 .select-viewport {
@@ -343,6 +346,7 @@
   align-items: center;
   justify-content: center;
 }
+
 .formic-spreadsheet-display-preview-button {
   height: 40px;
   width: 80px;

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -41,5 +41,12 @@
   "Manifest import failed": "Manifest import failed",
   "Import complete": "Import complete",
   "Select which canvas or canvases you would like to add as events.": "Select which canvas or canvases you would like to add as events.",
-  "Events": "Events"
+  "Events": "Events",
+  "Add Annotation": "Add Annotation",
+  "Edit Annotation": "Edit Annotation",
+  "Annotation Set": "Annotation Set",
+  "Annotation": "Annotation",
+  "Set": "Set",
+  "Add Set": "Add Set",
+  "All Annotations": "All Annotations"
 }

--- a/src/pages/[lang]/projects/[projectSlug]/events/[eventUuid]/index.astro
+++ b/src/pages/[lang]/projects/[projectSlug]/events/[eventUuid]/index.astro
@@ -31,7 +31,7 @@ if (!event) {
 <Layout title={event?.label || i18n.t['Add Event']} profile={info.profile}>
   <EventDetail
     event={event}
-    uuid={eventUuid}
+    eventUuid={eventUuid}
     i18n={i18n}
     project={projectData}
     projectSlug={projectSlug}

--- a/src/pages/api/projects/[projectName]/events/[eventUuid]/annotations/[annotationSetUuid]/[annotationUuid]/index.ts
+++ b/src/pages/api/projects/[projectName]/events/[eventUuid]/annotations/[annotationSetUuid]/[annotationUuid]/index.ts
@@ -16,7 +16,7 @@ const setup = async (cookies: AstroCookies) => {
 };
 
 export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
-  const { projectName, eventUuid, annotationFileUuid, annotationUuid } = params;
+  const { projectName, eventUuid, annotationSetUuid, annotationUuid } = params;
 
   const { token, info } = await setup(cookies);
 
@@ -25,7 +25,7 @@ export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
     !info ||
     !projectName ||
     !eventUuid ||
-    !annotationFileUuid ||
+    !annotationSetUuid ||
     !annotationUuid
   ) {
     return redirect('/', 307);
@@ -42,7 +42,7 @@ export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
     userInfo: info,
   });
 
-  const filePath = `/data/annotations/${annotationFileUuid}.json`;
+  const filePath = `/data/annotations/${annotationSetUuid}.json`;
 
   if (!exists(filePath)) {
     return new Response(null, {
@@ -87,11 +87,11 @@ export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
     });
   }
 
-  return new Response(JSON.stringify(annos), { status: 200 });
+  return new Response('ok', { status: 200 });
 };
 
 export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
-  const { projectName, eventUuid, annotationFileUuid, annotationUuid } = params;
+  const { projectName, eventUuid, annotationSetUuid, annotationUuid } = params;
 
   const { token, info } = await setup(cookies);
 
@@ -100,7 +100,7 @@ export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
     !info ||
     !projectName ||
     !eventUuid ||
-    !annotationFileUuid ||
+    !annotationSetUuid ||
     !annotationUuid
   ) {
     return redirect('/', 307);
@@ -119,7 +119,7 @@ export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
     userInfo: info,
   });
 
-  const filePath = `/data/annotations/${annotationFileUuid}.json`;
+  const filePath = `/data/annotations/${annotationSetUuid}.json`;
 
   if (!exists(filePath)) {
     return new Response(null, {

--- a/src/pages/api/projects/[projectName]/events/[eventUuid]/annotations/[annotationSetUuid]/index.ts
+++ b/src/pages/api/projects/[projectName]/events/[eventUuid]/annotations/[annotationSetUuid]/index.ts
@@ -22,11 +22,11 @@ export const POST: APIRoute = async ({
   request,
   redirect,
 }) => {
-  const { projectName, eventUuid, annotationFileUuid } = params;
+  const { projectName, eventUuid, annotationSetUuid } = params;
 
   const { token, info } = await setup(cookies);
 
-  if (!token || !info || !projectName || !eventUuid || !annotationFileUuid) {
+  if (!token || !info || !projectName || !eventUuid || !annotationSetUuid) {
     return redirect('/', 307);
   }
 
@@ -43,7 +43,7 @@ export const POST: APIRoute = async ({
     userInfo: info,
   });
 
-  const filePath = `/data/annotations/${annotationFileUuid}.json`;
+  const filePath = `/data/annotations/${annotationSetUuid}.json`;
 
   if (!exists(filePath)) {
     return new Response(null, {
@@ -70,7 +70,7 @@ export const POST: APIRoute = async ({
 
   writeFile(filePath, JSON.stringify(annos, null, '  '));
 
-  const commitMessage = `Added annotation ${newAnno.uuid} to annotation file ${annotationFileUuid} in event ${eventUuid}`;
+  const commitMessage = `Added annotation ${newAnno.uuid} to annotation file ${annotationSetUuid} in event ${eventUuid}`;
 
   const successCommit = await commitAndPush(commitMessage);
 

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -165,6 +165,7 @@ export type AnnotationEntry = {
 export type Annotation = {
   event_id: string;
   source_id: string;
+  set: string;
   annotations: AnnotationEntry[];
 };
 


### PR DESCRIPTION
# Summary

- implements the latest designs from Figma that allow the user to switch between sets
- refactors the `EventDetail` component to encapsulate the pieces of it a little better (it was getting pretty complex)
- adds debounce to the search feature because searching through 1000+ annotations is very computationally expensive and caused the UI to become choppy while typing
- implements the tag overflow system from Figma where the list of tags is restricted to one line with any others included in a count on the right
- renames the `annotationFileUuid` API param to `annotationSetUuid` to make it clearer that annotation files = sets

Keep in mind that this does not add the Add Set modal that's implied by the designs. I think we need to discuss how set management will work (if we can add a set, should we be able to delete a set? what about renaming them?) and preferably a design for the modal before starting on that.