### PR TITLE
Fix leaves not being included in `serialize` function

### DIFF
--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -145,7 +145,6 @@ export const Leaf = ({ attributes, children, leaf }: any) => {
 };
 
 export const serialize = (nodes: Node[]) => {
-  console.log(nodes);
   return nodes.map((node, idx) => {
     if (Text.isText(node)) {
       return <Leaf leaf={node}>{node.text}</Leaf>;


### PR DESCRIPTION
# Summary

This PR fixes a bug that prevented leaf-level properties (AKA inline, such as bold or italics) from showing up when running Slate nodes through `serialize`. The function now wraps all its outputs in the `Leaf` component, which picks up all that formatting.