### PR TITLE
Fix redirects and type error

### DIFF
--- a/src/apps/AnnotationImport/AnnotationImport.tsx
+++ b/src/apps/AnnotationImport/AnnotationImport.tsx
@@ -8,7 +8,7 @@ import {
 } from '@components/Formic/SpreadsheetInput/SpreadsheetInputContext.tsx';
 import { LoadingOverlay } from '@components/LoadingOverlay/index.ts';
 import { Button } from '@radix-ui/themes';
-import type { Event, ProjectData, Translations } from '@ty/Types.ts';
+import type { Event, ProjectData, Tags, Translations } from '@ty/Types.ts';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useContext, useMemo } from 'react';
 import { mapAnnotationData } from '@lib/parse/index.ts';

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,8 +6,8 @@ const lang = getLangFromUrl(Astro.url);
 const user = await userInfo(Astro.cookies);
 
 if (user) {
-  Astro.redirect(`/${lang}/projects`);
+  return Astro.redirect(`/${lang}/projects`);
 }
 
-Astro.redirect(`/${lang}/sign-in`);
+return Astro.redirect(`/${lang}/sign-in`);
 ---

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -15,7 +15,7 @@ const i18n = getTranslations(Astro.request, 'projects');
 const info = await userInfo(Astro.cookies);
 
 if (!info) {
-  Astro.redirect(`/${lang}/sign-in`);
+  return Astro.redirect(`/${lang}/sign-in`);
 }
 
 const allProjects: AllProjects = await getProjects(info as UserInfo);

--- a/src/pages/[lang]/projects/new.astro
+++ b/src/pages/[lang]/projects/new.astro
@@ -23,7 +23,7 @@ if (!info) {
 const provider = providers();
 
 if (!provider) {
-  Astro.redirect('/500');
+  return Astro.redirect('/500');
 }
 
 const orgs = await getOrgs(info);

--- a/src/pages/[lang]/sign-in.astro
+++ b/src/pages/[lang]/sign-in.astro
@@ -14,7 +14,7 @@ const cook = Astro.cookies.get('access-token');
 const token = cook ? cook.value : undefined;
 
 if (token) {
-  Astro.redirect(`/${lang}/projects`);
+  return Astro.redirect(`/${lang}/projects`);
 }
 ---
 

--- a/src/pages/[lang]/sign-out.astro
+++ b/src/pages/[lang]/sign-out.astro
@@ -1,5 +1,5 @@
 ---
 Astro.cookies.delete('access-token', { path: '/' });
 
-Astro.redirect('/');
+return Astro.redirect('/');
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,5 +9,5 @@ const lang = accepts
   ? parser.pick(Object.keys(languages), accepts)
   : defaultLang;
 
-Astro.redirect(`/${lang}/sign-in`);
+return Astro.redirect(`/${lang}/sign-in`);
 ---


### PR DESCRIPTION
# Summary

- adds `return` back to all the Astro redirects that it had been removed from
  - Astro won't redirect unless you `return` the redirect function call, as opposed to just calling it
- adds a missing import for the `Tags` type in one spot that was showing a TypeScript error