### PR TITLE
Use `_uncategorized_` for tag categories by default

### DIFF
--- a/src/lib/parse/index.ts
+++ b/src/lib/parse/index.ts
@@ -132,16 +132,16 @@ export const mapTagData = (
   let colorIndex = 0;
   data.forEach((d) => {
     if (d[map['tag_name']]) {
-      const category = d[map['tag_category']] || '_uncategorized_'
+      const category = d[map['tag_category']] ? d[map['tag_category']].trim() : '_uncategorized_'
       if (!ret.tagGroups.find((g) => g.category === category)) {
         ret.tagGroups.push({
-          category: category.trim(),
+          category,
           color: tagColors[colorIndex++],
         });
       }
       ret.tags.push({
         tag: d[map['tag_name']].trim(),
-        category: category.trim(),
+        category,
       });
     }
   });


### PR DESCRIPTION
# Summary

This PR fixes a crash that occurred when trying to import a tag CSV where some tags didn't have categories. The `mapTagData` function previously assumed that every tag would have a category. This PR sets `_uncategorized_` to be the default category when a tag doesn't have one.