### PR TITLE
Replace reference to "Visual" events with "Video"

### DIFF
--- a/src/lib/events/export.ts
+++ b/src/lib/events/export.ts
@@ -45,7 +45,7 @@ export const exportAnnotations = (
 
 export const exportEvents = (projectName: string, events: Event[]) => {
   let str =
-    'Event Label,Event Item Type (Audio or Visual),AVFile Label (might be the same as event label),AV File URL,Event Citation (optional),Event Description (optional)\n';
+    'Event Label,Event Item Type (Audio or Video),AVFile Label (might be the same as event label),AV File URL,Event Citation (optional),Event Description (optional)\n';
 
   events.forEach((event) => {
     Object.keys(event.audiovisual_files).forEach((uuid) => {


### PR DESCRIPTION
# Summary

Early in the development cycle we sometimes used the term "Visual" instead of "Video" to refer to video events. This PR replaces the one remaining instance of Visual in the admin client with Video.

Closes #84 