### PR TITLE
Autogenerate pages for events imported by manifest

### DIFF
--- a/src/lib/pages/autogenerate.ts
+++ b/src/lib/pages/autogenerate.ts
@@ -1,0 +1,61 @@
+import type { GitRepoContext } from '@backend/gitRepo.ts';
+import { findAutoGenHome } from './index.ts';
+import type { FormEvent, Page, UserInfo } from '@ty/Types.ts';
+import { v4 as uuidv4 } from 'uuid';
+
+export const autoGenerateEventPage = async (
+  context: GitRepoContext,
+  info: UserInfo,
+  ev: FormEvent,
+  eventUuid: string
+) => {
+  const homePageId = await findAutoGenHome(context);
+
+  const eventPage: Page = {
+    content: [],
+    created_at: new Date().toISOString(),
+    created_by: info!.profile.gitHubName || '',
+    title: ev.label,
+    updated_at: new Date().toISOString(),
+    updated_by: info!.profile.gitHubName || '',
+    parent: homePageId,
+    autogenerate: {
+      enabled: ev.auto_generate_web_page,
+      type: 'event',
+      type_id: eventUuid,
+    },
+  };
+
+  const pageId = uuidv4();
+  const successPage = await context.writeFile(
+    `/data/pages/${pageId}.json`,
+    JSON.stringify(eventPage, null, 2)
+  );
+
+  if (!successPage) {
+    console.error('Failed to write event page');
+    return new Response(null, {
+      status: 500,
+      statusText: 'Failed to write event page',
+    });
+  }
+
+  const orderFile = context.readFile('/data/pages/order.json');
+
+  const order = JSON.parse(orderFile as string);
+
+  order.push(pageId);
+
+  const successOrder = await context.writeFile(
+    '/data/pages/order.json',
+    JSON.stringify(order, null, 2)
+  );
+
+  if (!successOrder) {
+    console.error('Failed to write page order');
+    return new Response(null, {
+      status: 500,
+      statusText: 'Failed to write page order',
+    });
+  }
+};

--- a/src/pages/api/projects/[projectName]/events/[eventUuid]/index.ts
+++ b/src/pages/api/projects/[projectName]/events/[eventUuid]/index.ts
@@ -150,7 +150,6 @@ export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
     const contents = readFile(`/data/pages/${filepath}`);
     const parsed = JSON.parse(contents as string);
 
-    console.log(parsed);
     if (
       parsed &&
       parsed.autogenerate &&

--- a/src/pages/api/projects/[projectName]/events/import-manifest.ts
+++ b/src/pages/api/projects/[projectName]/events/import-manifest.ts
@@ -7,6 +7,7 @@ import { getRepositoryUrl } from '@backend/projectHelpers.ts';
 import { initFs } from '@lib/memfs/index.ts';
 import type { UserInfo, Event, ProjectData } from '@ty/Types.ts';
 import { emptyParagraph } from '@lib/slate/index.tsx';
+import { autoGenerateEventPage } from '@lib/pages/autogenerate.ts';
 
 // Create a new event
 export const POST: APIRoute = async ({
@@ -44,7 +45,7 @@ export const POST: APIRoute = async ({
       // Create new event and annotation records
       const repositoryURL = getRepositoryUrl(projectName);
 
-      const { writeFile, readFile, commitAndPush } = await gitRepo({
+      const { writeFile, readFile, commitAndPush, context } = await gitRepo({
         fs: initFs(),
         repositoryURL,
         branch: 'main',
@@ -81,6 +82,10 @@ export const POST: APIRoute = async ({
             auto_generate_web_page: body.auto_generate_web_page,
           };
           await writeFile(eventPath, JSON.stringify(event, null, 2));
+
+          if (body.auto_generate_web_page) {
+            await autoGenerateEventPage(context, info, event, eventRec.id);
+          }
 
           // Find any matching annotations
           for (let j = 0; j < results.annotations.length; j++) {

--- a/src/pages/api/projects/[projectName]/events/index.ts
+++ b/src/pages/api/projects/[projectName]/events/index.ts
@@ -3,11 +3,10 @@ import { getRepositoryUrl } from '@backend/projectHelpers.ts';
 import { userInfo } from '@backend/userInfo.ts';
 import { setTemplate } from '@lib/annotations/index.ts';
 import { initFs } from '@lib/memfs/index.ts';
+import { autoGenerateEventPage } from '@lib/pages/autogenerate.ts';
 import type { apiEventsPost } from '@ty/api.ts';
 import type { APIRoute } from 'astro';
 import { v4 as uuidv4 } from 'uuid';
-import type { Page } from '@ty/Types.ts';
-import { findAutoGenHome } from '@lib/pages/index.ts';
 
 // Create a new event
 export const POST: APIRoute = async ({
@@ -47,13 +46,12 @@ export const POST: APIRoute = async ({
 
   const fs = initFs();
 
-  const { exists, writeFile, readFile, commitAndPush, mkDir, context } =
-    await gitRepo({
-      fs,
-      repositoryURL,
-      branch: 'main',
-      userInfo: info,
-    });
+  const { exists, writeFile, commitAndPush, mkDir, context } = await gitRepo({
+    fs,
+    repositoryURL,
+    branch: 'main',
+    userInfo: info,
+  });
 
   const uuids: string[] = [];
 
@@ -122,56 +120,9 @@ export const POST: APIRoute = async ({
     }
 
     if (ev?.auto_generate_web_page) {
-      const homePageId = await findAutoGenHome(context);
-
-      const eventPage: Page = {
-        content: [],
-        created_at: new Date().toISOString(),
-        created_by: info!.profile.gitHubName || '',
-        title: ev.label,
-        updated_at: new Date().toISOString(),
-        updated_by: info!.profile.gitHubName || '',
-        parent: homePageId,
-        autogenerate: {
-          enabled: ev.auto_generate_web_page,
-          type: 'event',
-          type_id: uuid,
-        },
-      };
-
-      const pageId = uuidv4();
-      const successPage = await writeFile(
-        `/data/pages/${pageId}.json`,
-        JSON.stringify(eventPage, null, 2)
-      );
-
-      if (!successPage) {
-        console.error('Failed to write event page');
-        return new Response(null, {
-          status: 500,
-          statusText: 'Failed to write event page',
-        });
-      }
-
-      const orderFile = readFile('/data/pages/order.json');
-
-      const order = JSON.parse(orderFile as string);
-
-      order.push(pageId);
-
-      const successOrder = await writeFile(
-        '/data/pages/order.json',
-        JSON.stringify(order, null, 2)
-      );
-
-      if (!successOrder) {
-        console.error('Failed to write page order');
-        return new Response(null, {
-          status: 500,
-          statusText: 'Failed to write page order',
-        });
-      }
+      await autoGenerateEventPage(context, info, ev, uuid);
     }
+
     uuids.push(uuid);
   }
 


### PR DESCRIPTION
# Summary

- enables the auto-generate feature for events imported via manifest
- refactors the page autogeneration code from the event `POST` endpoint into a new `autoGenerateEventPage`, which is now shared by both the event `POST` endpoint and the `import-manifest` endpoint

Closes #78 