### PR TITLE
Remove AV file label column from annotation exports

### DIFF
--- a/src/apps/EventDetail/EventDetail.tsx
+++ b/src/apps/EventDetail/EventDetail.tsx
@@ -269,8 +269,7 @@ export const EventDetail: React.FC<EventDetailProps> = (props) => {
     if (currentSetUuid) {
       exportAnnotations(
         allAnnotations[currentSetUuid].annotations,
-        props.event,
-        avFile
+        props.event
       );
     }
   }, [currentSetUuid, allAnnotations, avFile]);

--- a/src/lib/events/export.ts
+++ b/src/lib/events/export.ts
@@ -10,13 +10,8 @@ const formatField = (str: string) => `"${str.replaceAll('"', '\\"')}"`;
 const serializeRichText = (nodes: Node[]) =>
   ReactDOMServer.renderToString(serialize(nodes));
 
-export const exportAnnotations = (
-  annos: AnnotationEntry[],
-  event: Event,
-  avFile: string
-) => {
-  let str =
-    'Start Time,End Time,Annotation,Tags (comma separated),AV Label (optional for single-file events)\n';
+export const exportAnnotations = (annos: AnnotationEntry[], event: Event) => {
+  let str = 'Start Time,End Time,Annotation,Tags (comma separated)\n';
 
   annos.forEach((anno) => {
     const fields = [
@@ -28,7 +23,6 @@ export const exportAnnotations = (
         : '',
       anno.annotation ? serializeRichText(anno.annotation) : '',
       anno.tags.map((t) => t.tag).join(',') || '',
-      event.audiovisual_files[avFile].label || '',
     ];
 
     str += fields.map(formatField).join(',');


### PR DESCRIPTION
# Summary

This PR removes the `AV Label (optional for single-file events)` column from the CSV file generated by the annotation export feature.

CSVs exported after this is merged will no longer display the extra column mentioned in #77:

<img width="834" alt="Screenshot 2024-09-16 at 3 48 03 PM" src="https://github.com/user-attachments/assets/a5da51a6-f8ee-40f4-b55c-b9f471bed87f">

Closes #77 