### PR TITLE
Fix "No Parent" option repeating on page edit form

### DIFF
--- a/src/components/PageForm/PageForm.tsx
+++ b/src/components/PageForm/PageForm.tsx
@@ -38,9 +38,9 @@ const FormContents: React.FC<Props> = (props) => {
 
   const parentPageOptions: { label: string; value: string | undefined }[] =
     useMemo(
-      () =>
-        // @ts-ignore
-        Object.keys(props.project.pages)
+      () => [
+        { label: t['No Parent'], value: undefined },
+        ...Object.keys(props.project.pages)
           .filter(
             (uuid) => uuid !== props.uuid && !props.project.pages![uuid].parent
           )
@@ -51,13 +51,9 @@ const FormContents: React.FC<Props> = (props) => {
               value: uuid,
             };
           }),
+      ],
       [props.uuid, props.project.pages]
     );
-
-  parentPageOptions.unshift({
-    label: t['No Parent'],
-    value: undefined,
-  });
 
   return (
     <Form className='page-form'>


### PR DESCRIPTION
# Summary

The "No Parent" option was being added with an `unshift` call that ran on every render, so any time the edit form component re-rendered the option would be added again to the start of the array.

This PR moves the No Parent option to the initial memoized `parentPageOptions` array.

Closes #87 