### PR TITLE
Remove media player helper text

### DIFF
--- a/src/components/ProjectForm/Fields.tsx
+++ b/src/components/ProjectForm/Fields.tsx
@@ -8,11 +8,6 @@ interface MediaPlayerFieldProps {
 export const MediaPlayerField: React.FC<MediaPlayerFieldProps> = (props) => (
   <TripleSwitchInput
     label={props.i18n.t['Media Player']}
-    helperText={
-      props.i18n.t[
-        'Your project can be presented using either the Universal Viewer or the Aviary Player to present media. Annotation-centered projects like digital editions generally work better with Universal Viewer, while media-centered projects like exhibitions may benefit from the Aviary Player. You can change viewers at any time in your project settings.'
-      ]
-    }
     name='media_player'
     optionLeft={{
       value: 'avannotate',

--- a/src/i18n/en/new-project.json
+++ b/src/i18n/en/new-project.json
@@ -12,7 +12,6 @@
   "Project Author(s)": "Project Author(s)",
   "Names will appear at the bottom of your project pages. If left blank, the project owners GitHub username will show instead.": "Names will appear at the bottom of your project pages. If left blank, the project owners GitHub username will show instead.",
   "Media Player": "Media Player",
-  "Your project can be presented using either the Universal Viewer or the Aviary Player to present media. Annotation-centered projects like digital editions generally work better with Universal Viewer, while media-centered projects like exhibitions may benefit from the Aviary Player. You can change viewers at any time in your project settings.": "Your project can be presented using either the Universal Viewer or the Aviary Player to present media. Annotation-centered projects like digital editions generally work better with Universal Viewer, while media-centered projects like exhibitions may benefit from the Aviary Player. You can change viewers at any time in your project settings.",
   "Universal Viewer": "Universal Viewer",
   "Aviary Player": "Aviary Player",
   "Auto-populate Home page": "Auto-populate Home page",


### PR DESCRIPTION
# Summary

This PR removes the helper text that appeared above the Media Player option in the "Create New Project" page. It also removes the string from the `i18n` JSON file because that was the only occurrence of it anywhere in the project.

Closes #93 