### PR TITLE
Create tags on import

### DIFF
--- a/src/apps/AnnotationImport/AnnotationImport.tsx
+++ b/src/apps/AnnotationImport/AnnotationImport.tsx
@@ -36,9 +36,15 @@ const onSubmit = async (
   headerMap: { [key: string]: number },
   baseUrl: string,
   redirectUrl: string,
-  tags: Tags
+  tags: Tags,
+  projectSlug: string
 ) => {
-  const annos = mapAnnotationData(body.annotations.data, headerMap, tags);
+  const annos = await mapAnnotationData(
+    body.annotations.data,
+    headerMap,
+    tags,
+    projectSlug
+  );
 
   const res = await fetch(`${baseUrl}/${body.set}`, {
     method: 'POST',
@@ -109,7 +115,8 @@ export const AnnotationImportForm: React.FC<Props> = (props) => {
           headerMap,
           baseUrl,
           redirectUrl,
-          props.project.project.tags
+          props.project.project.tags,
+          props.projectSlug
         )
       }
     >

--- a/src/apps/UploadTestApp/UploadTestApp.tsx
+++ b/src/apps/UploadTestApp/UploadTestApp.tsx
@@ -26,7 +26,7 @@ export const UploadTestApp = (_props: any) => {
 
   const handleMap = () => {
     if (output) {
-      const results = mapAnnotationData(
+      const results = await mapAnnotationData(
         output.data,
         {
           start_time: 0,


### PR DESCRIPTION
# Summary

- New behavior that adds new tags and tag categories on annotation import

# Testing Notes

Creating a new project and then importing these events:

https://docs.google.com/spreadsheets/d/1noYKA8DFaHkSLq-MXSPwCccY3YFeyR52/edit?gid=1808582907#gid=1808582907

And importing these annotations for one of the events:

https://docs.google.com/spreadsheets/d/12yn6zxviUpNLYESlGfUyWTc83wmFfsOM/edit?gid=92796109#gid=92796109

Should add 2 new categories, plus Uncategorized, and a number of tags
