### PR TITLE
Change margin to padding on page edit form

### DIFF
--- a/src/components/PageForm/PageForm.css
+++ b/src/components/PageForm/PageForm.css
@@ -3,7 +3,7 @@
 }
 
 .page-form .page-form-body {
-  margin-bottom: 100px;
+  padding-bottom: 100px;
 }
 
 .page-form .top-config-bar {


### PR DESCRIPTION
# Summary

This PR changes the `margin-bottom` CSS property to `padding-bottom` on the page form, fixing the white gap that appeared at the bottom of the page.

I noticed this issue while investigating #105 but I don't think it's related.