### PR TITLE
Add overflow to event description text area

### DIFF
--- a/src/components/EventForm/EventForm.css
+++ b/src/components/EventForm/EventForm.css
@@ -37,6 +37,10 @@
   width: 16px;
 }
 
+.event-form .formic-form-textarea {
+  overflow-y: auto;
+}
+
 .event-form .bottom-bar-flex {
   width: 100%;
   display: flex;


### PR DESCRIPTION
# Summary

This PR adds the `overflow-y: auto;` CSS property to the event description field in `EventForm`. This fixes an issue where long inputs would overflow the container and spill out over the page.

Closes #94 