### PR TITLE
Automatically set AV file duration where possible in event form

### DIFF
--- a/src/components/Formic/index.tsx
+++ b/src/components/Formic/index.tsx
@@ -117,11 +117,12 @@ export const RichTextInput = (props: RichTextInputProps) => {
 };
 
 interface TimeInputProps {
+  className?: string;
+  disabled?: boolean;
   initialValue: number;
   label?: string;
   onChange: (input: number) => any;
   required?: boolean;
-  className?: string;
 }
 
 export const TimeInput = (props: TimeInputProps) => {
@@ -164,6 +165,7 @@ export const TimeInput = (props: TimeInputProps) => {
       )}
       <input
         className='formic-form-text formic-time-input'
+        disabled={props.disabled}
         onChange={onChange}
         value={display}
       />

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -73,3 +73,20 @@ export const fromTimestamp = (str: string): number => {
 export const matchTag = (tag1: Tag, tag2: Tag) =>
   tag1.category.toLowerCase() === tag2.category.toLowerCase() &&
   tag1.tag === tag2.tag;
+
+const fetchableFileTypes = ['mp3', 'mp4', 'ogg', 'm4a'];
+
+export const getFileDuration = async (url: string): Promise<number | null> => {
+  if (fetchableFileTypes.includes(url.slice(-3))) {
+    // note: the Audio constructor can handle videos for this purpose too
+    return new Promise((resolve) => {
+      const audio = new Audio();
+      audio.onloadeddata = () => {
+        resolve(Math.floor(audio.duration));
+      };
+      audio.src = url;
+    });
+  }
+
+  return null;
+};


### PR DESCRIPTION
# Summary

- adds a new `getFileDuration` helper function that accepts a URL and attempts to find the duration of the audio/video using JS's `Audio` class (which, despite its name, works for video too and is a much simpler method to get duration than my originally proposed `react-player` solution)
  - the function will only attempt to fetch the file if it ends in one of the following extensions: `['mp3', 'mp4', 'ogg', 'm4a']`. This way, we aren't fetching constantly while the user is typing, and we aren't attempting to fetch stuff that we won't be able to get a duration from. This list can be expanded as needed.
- adds functionality to `EventForm` that watches the file URLs in the form and maintains a mapping of URLs with durations and applies those durations to any matching AV file
  - when an AV file's duration has been automatically fetched, its time input is disabled

## Video


https://github.com/user-attachments/assets/1d2b87d2-6e4b-4b82-a8f7-a48e744ccd93

