### PR TITLE
Remove all remaining placeholder text

### DIFF
--- a/src/apps/EventImport/EventImport.tsx
+++ b/src/apps/EventImport/EventImport.tsx
@@ -176,7 +176,11 @@ export const FormContents: React.FC<FormContentsProps> = (props) => {
         />
         <Separator.Root className='SeparatorRoot' decorative />
         <ToggleInput
-          helperText={t['lorem']}
+          helperText={
+            t[
+              'Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.'
+            ]
+          }
           label={t['Auto-generate web page for this event?']}
           name='autogenerate_web_pages'
         />

--- a/src/apps/NewEvent/NewEvent.tsx
+++ b/src/apps/NewEvent/NewEvent.tsx
@@ -71,7 +71,11 @@ export const NewEvent: React.FC<Props> = ({ i18n, project, projectSlug }) => {
           styles={{ display: tab === 0 ? 'initial' : 'none' }}
         >
           <ToggleInput
-            helperText={t['lorem']}
+            helperText={
+              t[
+                'Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.'
+              ]
+            }
             label={t['Auto-generate web page for this event?']}
             name='auto_generate_web_page'
           />

--- a/src/components/Formic/Formic.css
+++ b/src/components/Formic/Formic.css
@@ -43,12 +43,6 @@
   margin-top: 16px;
 }
 
-.formic-form-switch-container {
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 10px;
-}
-
 .formic-form-switch-button {
   width: 150px;
   height: 36px;
@@ -80,11 +74,8 @@
 }
 
 .formic-form-switch-container {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 12px;
   padding-top: 16px;
+  margin-bottom: 10px;
 }
 
 .formic-toggle-switch {

--- a/src/components/ImportForm/ImportForm.tsx
+++ b/src/components/ImportForm/ImportForm.tsx
@@ -73,8 +73,6 @@ const EventSelect = (props: EventSelectProps) => {
     }
   };
 
-  const handleDescriptionChange = (label: string, description: any) => {};
-
   return (
     <>
       <div className='import-form-event-header'>
@@ -146,7 +144,11 @@ const FormContents: React.FC<Props> = (props) => {
             </div>
             <DescriptionInput i18n={props.i18n} />
             <ToggleInput
-              helperText={t['lorem']}
+              helperText={
+                t[
+                  'Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.'
+                ]
+              }
               label={t['Auto-generate web page for these events?']}
               name='auto_generate_web_page'
             />

--- a/src/components/ImportForm/ImportForm.tsx
+++ b/src/components/ImportForm/ImportForm.tsx
@@ -146,7 +146,7 @@ const FormContents: React.FC<Props> = (props) => {
             <ToggleInput
               helperText={
                 t[
-                  'Selecting this will create a webpage for your events. You can edit or delete this page at any point in the Pages tab.'
+                  'Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab.'
                 ]
               }
               label={t['Auto-generate web page for these events?']}

--- a/src/components/ImportForm/ImportForm.tsx
+++ b/src/components/ImportForm/ImportForm.tsx
@@ -146,7 +146,7 @@ const FormContents: React.FC<Props> = (props) => {
             <ToggleInput
               helperText={
                 t[
-                  'Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.'
+                  'Selecting this will create a webpage for your events. You can edit or delete this page at any point in the Pages tab.'
                 ]
               }
               label={t['Auto-generate web page for these events?']}

--- a/src/components/ProjectForm/NewProjectForm.tsx
+++ b/src/components/ProjectForm/NewProjectForm.tsx
@@ -197,7 +197,13 @@ const FormContents = (props: NewProjectFormProps) => {
 
               <div ref={tagRef} />
               <h2>{t['Tags (optional)']}</h2>
-              <div className='av-label'>{t['lorem']}</div>
+              <div className='av-label'>
+                {
+                  t[
+                    'Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.'
+                  ]
+                }
+              </div>
               <SpreadsheetInput
                 accept='.tsv, .csv, .xlsx, .txt'
                 i18n={props.i18n}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -37,6 +37,5 @@
   "Edit Settings": "Edit Settings",
   "Choose File": "Choose File",
   "Select File": "Select File",
-  "Replace": "Replace",
-  "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.": "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups."
+  "Replace": "Replace"
 }

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -9,7 +9,6 @@
   "Video": "Video",
   "Other": "Other",
   "Add": "Add",
-  "lorem": "Lorem ipsum dolor sit amet consectetur. Id scelerisque diam in pellentesque leo. Justo faucibus aliquet sit eu leo quis. Nam quis cras aliquam scelerisque sagittis quis est.",
   "No file selected": "No file selected",
   "File configuration": "File configuration",
   "Column": "Column",
@@ -38,5 +37,6 @@
   "Edit Settings": "Edit Settings",
   "Choose File": "Choose File",
   "Select File": "Select File",
-  "Replace": "Replace"
+  "Replace": "Replace",
+  "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.": "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups."
 }

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -60,5 +60,6 @@
   "File": "File",
   "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.": "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.",
   "File Available Offline": "File Available Offline",
-  "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab."
+  "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.",
+  "Selecting this will create a webpage for your events. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your events. You can edit or delete this page at any point in the Pages tab."
 }

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -61,5 +61,5 @@
   "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.": "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.",
   "File Available Offline": "File Available Offline",
   "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.",
-  "Selecting this will create a webpage for your events. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your events. You can edit or delete this page at any point in the Pages tab."
+  "Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab.": "Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab."
 }

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -59,5 +59,6 @@
   "Offline": "Offline",
   "File": "File",
   "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.": "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.",
-  "File Available Offline": "File Available Offline"
+  "File Available Offline": "File Available Offline",
+  "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab."
 }

--- a/src/i18n/en/new-project.json
+++ b/src/i18n/en/new-project.json
@@ -31,5 +31,6 @@
   "Create Project": "Create Project",
   "Tag Name": "Tag Name",
   "Tag Category": "Tag Category",
-  "Import file contains column headers?": "Import file contains column headers?"
+  "Import file contains column headers?": "Import file contains column headers?",
+  "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.": "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups."
 }


### PR DESCRIPTION
# Summary

- removes the lorem ipsum text for the tag import toggle and the autogenerate pages toggle on the events form, replacing them with proper helper text
- removes the flex styling of the `ToggleInput` to match the Figma designs