### PR TITLE
Page ordering refactor

### DIFF
--- a/src/components/Formic/index.tsx
+++ b/src/components/Formic/index.tsx
@@ -205,9 +205,9 @@ export const SelectInput = (props: SelectInputProps) => {
       >
         {/* empty option to allow the user to leave the input blank */}
         {!props.required && <option />}
-        {props.options.map((option) => {
+        {props.options.map((option, idx) => {
           return (
-            <option key={option.value} value={option.value}>
+            <option key={option.value || idx} value={option.value}>
               {option.label}
             </option>
           );

--- a/src/components/PageForm/PageForm.tsx
+++ b/src/components/PageForm/PageForm.tsx
@@ -8,7 +8,7 @@ import { Form, Formik, useFormikContext } from 'formik';
 import './PageForm.css';
 import { BottomBar } from '@components/BottomBar/BottomBar.tsx';
 import { Button } from '@radix-ui/themes';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { InsertButton } from '@components/InsertEventButton/index.ts';
 import { emptyParagraph } from '@lib/slate/index.tsx';
 
@@ -32,7 +32,7 @@ interface Props {
 
 const FormContents: React.FC<Props> = (props) => {
   const { t } = props.i18n;
-  const { isSubmitting, values } = useFormikContext();
+  const { isSubmitting, setFieldValue, values } = useFormikContext();
 
   const hasTitle = useMemo(() => !!(values as FormPage).title, [values]);
 
@@ -54,6 +54,16 @@ const FormContents: React.FC<Props> = (props) => {
       ],
       [props.uuid, props.project.pages]
     );
+
+  // Radix UI seems to use the label as the value when an undefined value
+  // is provided. We have to get around this by watching the "No Parent"
+  // value and returning the form state to undefined when it's found.
+  useEffect(() => {
+    const parentValue = (values as FormPage).parent;
+    if (parentValue && parentValue === 'No Parent') {
+      setFieldValue('parent', undefined);
+    }
+  }, [(values as FormPage).parent]);
 
   return (
     <Form className='page-form'>

--- a/src/components/PageList/PageList.css
+++ b/src/components/PageList/PageList.css
@@ -44,7 +44,7 @@
   align-items: center;
 }
 
-.page-list .page-list .page-list-box-hovered {
+.page-list .page-list-box-hovered {
   border-bottom: 2px solid #62bdff !important;
 }
 

--- a/src/components/PageList/PageList.tsx
+++ b/src/components/PageList/PageList.tsx
@@ -72,7 +72,7 @@ export const PageList: React.FC<Props> = (props) => {
   };
 
   const handleDisableAutoGeneration = async (uuid: string) => {
-    let copy: ProjectData = JSON.parse(JSON.stringify(project));
+    const copy: ProjectData = JSON.parse(JSON.stringify(project));
 
     const page = copy.pages[uuid];
     page.autogenerate.enabled = false;
@@ -96,7 +96,7 @@ export const PageList: React.FC<Props> = (props) => {
   };
 
   const handleReEnableAutoGeneration = async (uuid: string) => {
-    let copy: ProjectData = JSON.parse(JSON.stringify(project));
+    const copy: ProjectData = JSON.parse(JSON.stringify(project));
 
     const page = copy.pages[uuid];
     if (['home', 'event'].includes(page.autogenerate.type)) {

--- a/src/lib/pages/index.ts
+++ b/src/lib/pages/index.ts
@@ -4,37 +4,61 @@ import type { GitRepoContext } from '@backend/gitRepo.ts';
 export const getNewOrder = (
   allPages: { [key: string]: Page },
   uuid: string,
-  orderFileContent: string[]
-) => {
+  orderFileContent: string[],
+  oldPage?: Page
+): string[] => {
+  const newPage = allPages[uuid];
+
+  // return the same order file content if the parent didn't change
+  // (the only way to change the page order from the page edit form
+  // is to add/remove/change the page's parent UUID)
+  if (oldPage && oldPage.parent === newPage.parent) {
+    return orderFileContent;
+  }
+
   const newOrder = orderFileContent.filter((item) => item !== uuid);
 
-  if (allPages[uuid].parent) {
-    // insert the page as the final child under its parent
-    const parentIdx = newOrder.indexOf(allPages[uuid].parent!);
-
-    if (parentIdx === newOrder.length - 1) {
-      // if the parent is the last element in the array,
-      // we can just push to the end
-      newOrder.push(uuid);
-    } else {
-      const nextParentIdx =
-        newOrder.slice(parentIdx + 1).findIndex((key) => {
-          return !allPages[key].parent;
-        }) +
-        parentIdx +
-        1;
-
-      // if the page's parent is the last parent-level
-      // page in the project, then place the new page
-      // at the bottom
-      if (nextParentIdx === -1) {
-        newOrder.push(uuid);
-      } else {
-        newOrder.splice(nextParentIdx, 0, uuid);
-      }
-    }
-  } else {
+  // bump it to the bottom if we removed the page's parent
+  if (oldPage && oldPage.parent && !newPage.parent) {
     newOrder.push(uuid);
+    return newOrder;
+  }
+
+  // all parent pages, sorted by their order file index
+  const parentPages = (
+    Object.keys(allPages)
+      .map((pageUuid) => {
+        if (!allPages[pageUuid].parent) {
+          return { uuid: pageUuid, idx: newOrder.indexOf(pageUuid) };
+        }
+      })
+      .filter(Boolean) as { uuid: string; idx: number }[]
+  ).sort((a, b) => {
+    if (a.idx > b.idx) {
+      return 1;
+    } else if (b.idx > a.idx) {
+      return -1;
+    }
+
+    return 0;
+  });
+
+  // if we just added a parent to a previously parentless page, add it to the
+  // bottom of that parent's list of children
+  const parentPage = parentPages.find((pp) => pp.uuid === newPage.parent);
+
+  if (!parentPage) {
+    throw new Error("Parent page doesn't exist in project.");
+  }
+
+  const nextParentPage =
+    parentPages[parentPages.map((pp) => pp.idx).indexOf(parentPage.idx) + 1];
+
+  // if the chosen parent page is at the end, we can just push the UUID to the bottom
+  if (!nextParentPage) {
+    newOrder.push(uuid);
+  } else {
+    newOrder.splice(nextParentPage.idx, 0, uuid);
   }
 
   return newOrder;


### PR DESCRIPTION
# Summary

This PR refactors (basically rewrites) the `getNewOrder` function and the pages `PUT` route to address an unanticipated number of edge cases that weren't properly handled by the old system. I think the new code is logically easier to follow (we do different things depending on the relation between the page's new parent and its old parent) and make changes to if needed, and is just semantically simpler, while the old code was a trial-and-error mess that I hacked out early in the project.

Additionally, it includes the following changes:

- proper handling for when a page with children is made into a child of another component (its children follow it and become siblings under the new parent)
- fix a bad class name that was preventing the blue highlight from coming up when you're dragging a page to reorder (this looked like a rebase causality)
- fix a really weird issue where the page form was setting a page's parent as "No Parent" instead of leaving the field undefined even when we set a value of `undefined` in the select menu
- fix a React keys warning in the select menu when an option has an `undefined` value (as we give it in the page form)

# Testing

Note: This PR deals with the reordering that occurs when you change a page's parent via the edit form, *not* the drag-and-drop reordering feature. Any bugs found in that feature should be filed separately and shouldn't block this PR.

The updated function handles several cases:

1. When a page **has** a parent and you edit it without changing the parent, its place in the order should **stay the same**.
2. When a page **does not have** a parent and you edit it without adding a parent, its place should **stay the same**.
3. When a page **does not have** a parent and you add a parent, it should be placed **at the bottom of the list of its parent's children**.
4. When a page **has** a parent and you edit it to remove the parent, it should be placed **at the bottom of the list**.
5. When a page **has** a parent and you edit it to assign it to a different parent, it should be placed **at the bottom of the list of its new parent's children**.
6. When a page **has children** and you add a parent to it, the page should be placed **in the list of its new parent's children** (order isn't super important here) and its former children should all have followed it into the list below the new parent. Each of its former children should also be updated to list the new parent as their parent (the only way to verify this is to open their edit pages).