### PR TITLE
Fix page order issue for new parentless pages

### DIFF
--- a/src/lib/pages/index.ts
+++ b/src/lib/pages/index.ts
@@ -24,6 +24,12 @@ export const getNewOrder = (
     return newOrder;
   }
 
+  // if it's a new page with no parent, add it straight to the bottom
+  if (!oldPage && !newPage.parent) {
+    newOrder.push(uuid);
+    return newOrder;
+  }
+
   // all parent pages, sorted by their order file index
   const parentPages = (
     Object.keys(allPages)


### PR DESCRIPTION
This small PR addresses a bug from #116 where the new `getNewOrder` function didn't handle newly created parentless pages and crashed.