### PR TITLE
Automate durations for event imports

### DIFF
--- a/src/apps/EventImport/EventImport.css
+++ b/src/apps/EventImport/EventImport.css
@@ -21,3 +21,28 @@
 .event-import-form .bottom-bar-flex .cancel-button {
   width: 176px;
 }
+
+.event-import-duration-dialog-content .dialog-close-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 20px;
+  margin-top: 20px;
+  width: 100%;
+}
+
+.event-import-duration-dialog-content .dialog-close-bar button {
+  height: 40px;
+  width: 80px;
+  box-shadow: none;
+  border-radius: 4px;
+}
+
+.event-import-duration-dialog-content label {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.event-import-duration-dialog-content .formic-time-input {
+  max-width: 100px;
+}

--- a/src/apps/EventImport/EventImport.tsx
+++ b/src/apps/EventImport/EventImport.tsx
@@ -115,7 +115,6 @@ export const FormContents: React.FC<FormContentsProps> = (props) => {
 
   const { setFieldValue, submitForm, values } = useFormikContext();
 
-  // returns whether the durations are all set to be saved or not
   const transformData = async (data: any) => {
     setSaving(true);
 

--- a/src/apps/EventImport/EventImport.tsx
+++ b/src/apps/EventImport/EventImport.tsx
@@ -136,7 +136,6 @@ export const FormContents: React.FC<FormContentsProps> = (props) => {
       for await (const afUuid of Object.keys(ev.audiovisual_files)) {
         const file = ev.audiovisual_files[afUuid];
 
-        console.log('hello');
         const duration = await getFileDuration(file.file_url);
 
         if (duration) {

--- a/src/components/LoadingOverlay/LoadingOverlay.css
+++ b/src/components/LoadingOverlay/LoadingOverlay.css
@@ -8,5 +8,5 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 99999;
+  z-index: 9999999;
 }

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -61,5 +61,6 @@
   "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.": "Upload a .tsv, .csv, .xlsx, or tab-separated .txt file of annotations that correspond with your project’s audiovisual item. If you have multiple annotation layers, upload them individually.",
   "File Available Offline": "File Available Offline",
   "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.": "Selecting this will create a webpage for your event. You can edit or delete this page at any point in the Pages tab.",
-  "Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab.": "Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab."
+  "Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab.": "Selecting this will create webpages for your events. You can edit or delete these pages at any point in the Pages tab.",
+  "We were unable to fetch the duration of the following file(s). Please enter them below.": "We were unable to fetch the duration of the following file(s). Please enter them below."
 }

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -84,6 +84,9 @@ export const getFileDuration = async (url: string): Promise<number | null> => {
       audio.onloadeddata = () => {
         resolve(Math.floor(audio.duration));
       };
+      audio.onerror = () => {
+        resolve(null);
+      };
       audio.src = url;
     });
   }


### PR DESCRIPTION
# Summary

- adds handling to the `EventImport` component to fill in durations for each AV file automatically using the `getFileDuration` helper function
- adds functionality to manually enter durations if the auto-detection fails

# Testing

There are two possible paths through the Event Import component.

Importing the CSV with good URLs should have the same import behavior as before - you hit save, it spins for a few seconds, then you're redirected to the project page and you can see the new events.

Importing the CSV containing a *bad* URL, a modal should pop up prompting you to input a URL. There should be a listing for each bad URL. Hitting save on this modal should save the events and redirect you to the project page. You should be able to see the durations you entered on the corresponding event settings pages.

In real life, of course, we'd prefer that people import with working URLs. But there may be other situations, like flaky servers, where we need this fallback for durations instead of just blocking the user from importing the CSV.