### PR TITLE
Fix for export of tags

### DIFF
--- a/src/lib/events/export.ts
+++ b/src/lib/events/export.ts
@@ -11,7 +11,7 @@ const serializeRichText = (nodes: Node[]) =>
   ReactDOMServer.renderToString(serialize(nodes));
 
 export const exportAnnotations = (annos: AnnotationEntry[], event: Event) => {
-  let str = 'Start Time,End Time,Annotation,Tags (comma separated)\n';
+  let str = 'Start Time,End Time,Annotation,Tags (vertical bar separated)\n';
 
   annos.forEach((anno) => {
     const fields = [
@@ -22,7 +22,7 @@ export const exportAnnotations = (annos: AnnotationEntry[], event: Event) => {
         ? formatTimestamp(anno.end_time, false)
         : '',
       anno.annotation ? serializeRichText(anno.annotation) : '',
-      anno.tags.map((t) => t.tag).join(',') || '',
+      anno.tags.map((t) => t.tag).join('|') || '',
     ];
 
     str += fields.map(formatField).join(',');


### PR DESCRIPTION
# Summary

Now that imported annotation tags use the pipe character for separation, so should annotation export