### PR TITLE
Disable event import duration modal save button until all durations are entered

### DIFF
--- a/src/apps/EventImport/EventImport.tsx
+++ b/src/apps/EventImport/EventImport.tsx
@@ -264,7 +264,18 @@ export const FormContents: React.FC<FormContentsProps> = (props) => {
                     <Button
                       className='primary'
                       role='button'
-                      onClick={submitForm}
+                      onClick={() => {
+                        setFailedDurations([]);
+                        submitForm();
+                      }}
+                      disabled={
+                        !!(values as typeof initialValues).body.find(
+                          (ev) =>
+                            !ev.audiovisual_files[
+                              Object.keys(ev.audiovisual_files)[0]
+                            ].duration
+                        )
+                      }
                     >
                       {t['save']}
                     </Button>

--- a/src/components/LoadingOverlay/LoadingOverlay.css
+++ b/src/components/LoadingOverlay/LoadingOverlay.css
@@ -8,5 +8,5 @@
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 9999999;
+  z-index: 999999999;
 }


### PR DESCRIPTION
# Summary

- addresses #141 by disabling the Save button in the modal as long as any AV file durations are 0
- improves saving behavior by closing the modal when you hit save so you can see the loading spinner instead of it being behind the modal