### PR TITLE
Add table of contents component to rich text editor

### DIFF
--- a/src/components/Formic/SlateInput/SlateInput.tsx
+++ b/src/components/Formic/SlateInput/SlateInput.tsx
@@ -163,7 +163,7 @@ const MarkButton = (props: SlateButtonProps) => {
   );
 };
 
-const insertTableofContents = (editor: BaseEditor & ReactEditor) => {
+const insertTableOfContents = (editor: BaseEditor & ReactEditor) => {
   const nodes = [
     {
       type: 'table-of-contents',
@@ -237,8 +237,6 @@ export const SlateInput: React.FC<Props> = (props) => {
 
   const { t } = props.i18n;
 
-  console.log(editor);
-
   return (
     <div className='slate-form'>
       <Slate
@@ -269,7 +267,7 @@ export const SlateInput: React.FC<Props> = (props) => {
               <BlockButton
                 format='table-of-contents'
                 icon={BookmarkIcon}
-                onInsert={insertTableofContents}
+                onInsert={insertTableOfContents}
               />
               <div className='toolbar-separator' />
               <BlockButton format='left' icon={JustifyLeft} />

--- a/src/components/Formic/SlateInput/SlateInput.tsx
+++ b/src/components/Formic/SlateInput/SlateInput.tsx
@@ -9,6 +9,7 @@ import {
 } from 'slate';
 import { Button } from '@radix-ui/themes';
 import {
+  BookmarkIcon,
   CodeIcon,
   FontBoldIcon,
   FontItalicIcon,
@@ -122,6 +123,7 @@ const isMarkActive = (editor: ReactEditor, format: string) => {
 
 const BlockButton = (props: SlateButtonProps) => {
   const editor = useSlate();
+
   return (
     <Button
       className={`block-button unstyled ${
@@ -129,7 +131,11 @@ const BlockButton = (props: SlateButtonProps) => {
       }`}
       onMouseDown={(event) => {
         event.preventDefault();
-        toggleBlock(editor, props.format);
+        if (props.onInsert) {
+          props.onInsert(editor);
+        } else {
+          toggleBlock(editor, props.format);
+        }
       }}
       type='button'
     >
@@ -157,6 +163,22 @@ const MarkButton = (props: SlateButtonProps) => {
   );
 };
 
+const insertTableofContents = (editor: BaseEditor & ReactEditor) => {
+  const nodes = [
+    {
+      type: 'table-of-contents',
+      children: [{ text: '' }],
+    },
+    {
+      type: 'paragraph',
+      children: [{ text: '' }],
+    },
+  ];
+
+  // @ts-ignore
+  Transforms.insertNodes(editor, nodes);
+};
+
 const insertImage = (editor: BaseEditor & ReactEditor, image: ImageData) => {
   const nodes = [
     {
@@ -178,8 +200,9 @@ const withAVAPlugin = (editor: BaseEditor & ReactEditor) => {
   const { isVoid } = editor;
 
   editor.isVoid = (el) => {
-    // @ts-ignore
-    if (el.type === 'image' || el.type === 'horizontal-separator') {
+    if (
+      ['image', 'horizontal-separator', 'table-of-contents'].includes(el.type)
+    ) {
       return true;
     }
 
@@ -214,6 +237,8 @@ export const SlateInput: React.FC<Props> = (props) => {
 
   const { t } = props.i18n;
 
+  console.log(editor);
+
   return (
     <div className='slate-form'>
       <Slate
@@ -241,6 +266,11 @@ export const SlateInput: React.FC<Props> = (props) => {
             <>
               <BlockButton format='numbered-list' icon={ListOl} />
               <BlockButton format='bulleted-list' icon={ListUl} />
+              <BlockButton
+                format='table-of-contents'
+                icon={BookmarkIcon}
+                onInsert={insertTableofContents}
+              />
               <div className='toolbar-separator' />
               <BlockButton format='left' icon={JustifyLeft} />
               <BlockButton format='center' icon={TextCenter} />

--- a/src/components/PageForm/PageForm.css
+++ b/src/components/PageForm/PageForm.css
@@ -50,3 +50,13 @@
 .page-form .slate-column:last-child {
   border-left: none;
 }
+
+.page-form .table-of-contents {
+  height: 120px;
+  width: 360px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--gray-100);
+  border: 1px solid var(--gray-200);
+}

--- a/src/i18n/en/pages.json
+++ b/src/i18n/en/pages.json
@@ -32,5 +32,6 @@
   "full": "Full",
   "Audiovisual File": "Audiovisual File",
   "No Parent": "No Parent",
-  "Horizontal Separator": "Horizontal Separator"
+  "Horizontal Separator": "Horizontal Separator",
+  "Table of Contents": "Table of Contents"
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -19,11 +19,11 @@ export const getLangFromUrl = (url: URL) => {
   return defaultLang;
 };
 
-export const getTranslations = (
-  request: Request,
+export const getTranslationsFromUrl = (
+  url: string,
   dictionary: keyof typeof defaultLabels
 ): Translations => {
-  const lang = getLangFromUrl(new URL(request.url));
+  const lang = getLangFromUrl(new URL(url));
 
   return {
     lang,
@@ -33,3 +33,8 @@ export const getTranslations = (
     },
   };
 };
+
+export const getTranslations = (
+  request: Request,
+  dictionary: keyof typeof defaultLabels
+): Translations => getTranslationsFromUrl(request.url, dictionary);

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -2,6 +2,7 @@ import {
   EmbeddedEvent,
   EmbeddedEventComparison,
 } from '@components/EmbeddedEvent/index.ts';
+import { getTranslationsFromUrl } from '@i18n';
 import { Node, Text, type Descendant } from 'slate';
 
 export const Element = ({
@@ -167,6 +168,8 @@ export const Leaf = ({ attributes, children, leaf }: any) => {
 };
 
 export const serialize = (nodes: Node[]) => {
+  const i18n = getTranslationsFromUrl(window.location.href, 'pages');
+
   return nodes.map((node, idx) => {
     if (Text.isText(node)) {
       return (
@@ -180,7 +183,9 @@ export const serialize = (nodes: Node[]) => {
       const children = node.children.map((node) => serialize([node]));
       return (
         <Leaf leaf={node} key={idx}>
-          <Element element={node}>{children}</Element>
+          <Element element={node} i18n={i18n}>
+            {children}
+          </Element>
         </Leaf>
       );
     } else {

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -12,6 +12,9 @@ export const Element = ({
   i18n,
 }: any) => {
   const style = { textAlign: element.align };
+
+  const { t } = i18n;
+
   switch (element.type) {
     case 'block-quote':
       return (
@@ -53,6 +56,18 @@ export const Element = ({
       return (
         <div {...attributes} style={style} contentEditable={false}>
           <img src={element.url} className={`slate-img-${element.size}`} />
+          {children}
+        </div>
+      );
+    case 'table-of-contents':
+      return (
+        <div
+          {...attributes}
+          className='table-of-contents'
+          style={style}
+          contentEditable={false}
+        >
+          <p contentEditable={false}>{t['Table of Contents']}</p>
           {children}
         </div>
       );

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,3 +1,6 @@
+import type { BaseEditor } from 'slate';
+import type { ReactEditor } from 'slate-react';
+
 export interface MeatballMenuItem {
   label: string;
   onClick: (item: any) => any | Promise<any>;
@@ -14,4 +17,5 @@ export interface DraggedPage {
 export interface SlateButtonProps {
   format: string;
   icon: React.FC;
+  onInsert?: (editor: BaseEditor & ReactEditor) => void;
 }


### PR DESCRIPTION
# Summary

This PR adds a new `table-of-contents` block element type to the rich text editor on the page form.

On the admin side, we use a placeholder similar to the way we use a placeholder for the event embeds:

<img width="395" alt="Screenshot 2024-10-02 at 3 28 24 PM" src="https://github.com/user-attachments/assets/2a88ce14-88a7-44d6-a653-c17dbe683379">

The project client will build the actual list of pages during the build process. In theory, we could display an actual table of contents right here in the RTE, but it would add complexity to the component and it might be confusing to insert a bunch of text that the user can't edit.