### PR TITLE
Fix issues with event export and annotation import

### DIFF
--- a/src/lib/events/export.ts
+++ b/src/lib/events/export.ts
@@ -4,8 +4,9 @@ import { formatTimestamp } from './index.ts';
 import ReactDOMServer from 'react-dom/server';
 import type { Node } from 'slate';
 
-// add a \ to escape any quotes, and surround the value in quotes
-const formatField = (str: string) => `"${str.replaceAll('"', '\\"')}"`;
+// add another quote to escape any quotes, and surround the value in quotes
+// (see https://stackoverflow.com/a/17808731)
+const formatField = (str: string) => `"${str.replaceAll('"', '""')}"`;
 
 const serializeRichText = (nodes: Node[]) =>
   ReactDOMServer.renderToString(serialize(nodes));

--- a/src/lib/parse/index.ts
+++ b/src/lib/parse/index.ts
@@ -103,11 +103,11 @@ export const mapAnnotationData = async (
     let annotation = deserialize(template.content);
 
     // handle plan text imports, which need to be in a paragraph node
-    if (!Array.isArray(annotation)) {
+    if (annotation.length === 1 && Object.hasOwn(annotation[0], 'text')) {
       annotation = [
         {
-          ...emptyParagraph,
-          children: [annotation],
+          ...emptyParagraph[0],
+          children: [annotation[0]],
         },
       ];
     }

--- a/src/lib/parse/index.ts
+++ b/src/lib/parse/index.ts
@@ -100,7 +100,7 @@ export const mapAnnotationData = async (
     const template = document.createElement('template');
     template.innerHTML = d[map['annotation']];
 
-    let annotation = deserialize(template.content.firstChild!);
+    let annotation = deserialize(template.content);
 
     // handle plan text imports, which need to be in a paragraph node
     if (!Array.isArray(annotation)) {

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -100,11 +100,17 @@ export const Element = ({
           {children}
         </div>
       );
-    default:
+    case 'paragraph':
       return (
         <p style={style} {...attributes}>
           {children}
         </p>
+      );
+    default:
+      return (
+        <div style={style} {...attributes}>
+          {children}
+        </div>
       );
   }
 };


### PR DESCRIPTION
# Summary

This PR fixes the two issues reported in #127

1. For event *exports*, strings were being incorrectly escaped with `/` when the correct way according to spec is to use an extra quotation mark.
2. For annotation imports, we were calling `firstChild` from the annotation's HTML content which meant it only saved the first HTML element. I think this was originally a fix for plain text annotations (i.e. regular strings without HTML formatting), so I had to redo the handling for plain text annotations to prevent them from getting a bad Slate node structure.