### PR TITLE
Fix undefined `i18n` error

### DIFF
--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -197,7 +197,7 @@ export const serialize = (nodes: Node[]) => {
     } else {
       return (
         <Leaf leaf={node} key={idx}>
-          <Element element={node} />
+          <Element element={node} i18n={i18n} />
         </Leaf>
       );
     }


### PR DESCRIPTION
# Summary

This PR fixes a crash in the event viewer that occurred as a result of #143 adding an `i18n` prop requirement to the rich text `Element` component.