### PR TITLE
Human readable URL's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "slate": "^0.103.0",
         "slate-hyperscript": "^0.100.0",
         "slate-react": "^0.105.0",
+        "slugify": "^1.6.6",
         "typescript": "^5.4.5",
         "uuid": "^10.0.0",
         "webvtt-parser": "^2.2.0",
@@ -12198,6 +12199,14 @@
         "react": ">=18.2.0",
         "react-dom": ">=18.2.0",
         "slate": ">=0.99.0"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "slate": "^0.103.0",
     "slate-hyperscript": "^0.100.0",
     "slate-react": "^0.105.0",
+    "slugify": "^1.6.6",
     "typescript": "^5.4.5",
     "uuid": "^10.0.0",
     "webvtt-parser": "^2.2.0",

--- a/src/lib/pages/autogenerate.ts
+++ b/src/lib/pages/autogenerate.ts
@@ -1,7 +1,12 @@
 import type { GitRepoContext } from '@backend/gitRepo.ts';
-import { findAutoGenHome } from './index.ts';
+import {
+  findAutoGenHome,
+  trimStringToMaxLength,
+  ensureUniqueSlug,
+} from './index.ts';
 import type { FormEvent, Page, UserInfo } from '@ty/Types.ts';
 import { v4 as uuidv4 } from 'uuid';
+import slugify from 'slugify';
 
 export const autoGenerateEventPage = async (
   context: GitRepoContext,
@@ -11,11 +16,15 @@ export const autoGenerateEventPage = async (
 ) => {
   const homePageId = await findAutoGenHome(context);
 
+  const maxTitle = trimStringToMaxLength(ev.label, 20);
+  const slug = ensureUniqueSlug(maxTitle, context);
+
   const eventPage: Page = {
     content: [],
     created_at: new Date().toISOString(),
     created_by: info!.profile.gitHubName || '',
     title: ev.label,
+    slug: slug,
     updated_at: new Date().toISOString(),
     updated_by: info!.profile.gitHubName || '',
     parent: homePageId,

--- a/src/lib/pages/autogenerate.ts
+++ b/src/lib/pages/autogenerate.ts
@@ -6,7 +6,6 @@ import {
 } from './index.ts';
 import type { FormEvent, Page, UserInfo } from '@ty/Types.ts';
 import { v4 as uuidv4 } from 'uuid';
-import slugify from 'slugify';
 
 export const autoGenerateEventPage = async (
   context: GitRepoContext,
@@ -16,8 +15,7 @@ export const autoGenerateEventPage = async (
 ) => {
   const homePageId = await findAutoGenHome(context);
 
-  const maxTitle = trimStringToMaxLength(ev.label, 20);
-  const slug = ensureUniqueSlug(maxTitle, context);
+  const slug = ensureUniqueSlug(ev.label, context);
 
   const eventPage: Page = {
     content: [],

--- a/src/lib/pages/index.ts
+++ b/src/lib/pages/index.ts
@@ -2,6 +2,8 @@ import type { Page, ProjectFile } from '@ty/Types.ts';
 import type { GitRepoContext } from '@backend/gitRepo.ts';
 import slugify from 'slugify';
 
+const MAX_SLUG_LENGTH = 20;
+
 export const getNewOrder = (
   allPages: { [key: string]: Page },
   uuid: string,
@@ -131,7 +133,9 @@ export const trimStringToMaxLength = (str: string, maxLength: number) => {
   }
 };
 
-export const ensureUniqueSlug = (slug: string, context: GitRepoContext) => {
+export const ensureUniqueSlug = (slugIn: string, context: GitRepoContext) => {
+  const slug = trimStringToMaxLength(slugIn, MAX_SLUG_LENGTH);
+
   // @ts-ignore
   let ret = slugify(slug, { lower: true, strict: true });
 
@@ -152,7 +156,11 @@ export const ensureUniqueSlug = (slug: string, context: GitRepoContext) => {
         );
 
         if (page.slug === ret) {
-          ret = ret.slice(0, -1) + `${num++}`;
+          if (slug.length >= MAX_SLUG_LENGTH - 1) {
+            ret = ret.slice(0, -1) + `-${num++}`;
+          } else {
+            ret = ret + `-${num++}`;
+          }
         }
       });
 

--- a/src/lib/pages/index.ts
+++ b/src/lib/pages/index.ts
@@ -1,5 +1,6 @@
 import type { Page, ProjectFile } from '@ty/Types.ts';
 import type { GitRepoContext } from '@backend/gitRepo.ts';
+import slugify from 'slugify';
 
 export const getNewOrder = (
   allPages: { [key: string]: Page },
@@ -120,4 +121,45 @@ export const updateProjectLastUpdated = async (
   }
 
   return false;
+};
+
+export const trimStringToMaxLength = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) {
+    return str;
+  } else {
+    return str.slice(0, maxLength);
+  }
+};
+
+export const ensureUniqueSlug = (slug: string, context: GitRepoContext) => {
+  // @ts-ignore
+  let ret = slugify(slug, { lower: true, strict: true });
+
+  const { readDir, readFile } = context;
+
+  const pages = readDir('/data/pages');
+  let num = 2;
+  let repeat = true;
+  while (repeat) {
+    const start = num;
+    pages
+      .filter(
+        (filename) => filename !== '.gitkeep' && filename !== 'order.json'
+      )
+      .forEach((filename) => {
+        const page: Page = JSON.parse(
+          readFile(`/data/pages/${filename}`) as string
+        );
+
+        if (page.slug === ret) {
+          ret = ret.slice(0, -1) + `${num++}`;
+        }
+      });
+
+    if (num === start) {
+      repeat = false;
+    }
+  }
+
+  return ret;
 };

--- a/src/pages/api/projects/[projectName]/events/[eventUuid]/index.ts
+++ b/src/pages/api/projects/[projectName]/events/[eventUuid]/index.ts
@@ -108,8 +108,7 @@ export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
           parsedContent.title = event.label;
           if (originalEvent.label !== event.label) {
             // rename the slug
-            const maxTitle = trimStringToMaxLength(event.label, 20);
-            parsedContent.slug = ensureUniqueSlug(maxTitle, context);
+            parsedContent.slug = ensureUniqueSlug(event.label, context);
           }
           writeFile(
             `/data/pages/${filename}`,

--- a/src/pages/api/projects/[projectName]/pages/[pageUuid].ts
+++ b/src/pages/api/projects/[projectName]/pages/[pageUuid].ts
@@ -67,8 +67,7 @@ export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
   ) as Page;
 
   if (oldPage.title !== page.title) {
-    const maxTitle = trimStringToMaxLength(body.page?.title as string, 20);
-    const pageSlug = ensureUniqueSlug(maxTitle, context);
+    const pageSlug = ensureUniqueSlug(body.page?.title, context);
 
     page.slug = pageSlug;
   }

--- a/src/pages/api/projects/[projectName]/pages/[pageUuid].ts
+++ b/src/pages/api/projects/[projectName]/pages/[pageUuid].ts
@@ -2,7 +2,12 @@ import { gitRepo } from '@backend/gitRepo.ts';
 import { getPageData, getRepositoryUrl } from '@backend/projectHelpers.ts';
 import { userInfo } from '@backend/userInfo.ts';
 import { initFs } from '@lib/memfs/index.ts';
-import { getNewOrder, updateProjectLastUpdated } from '@lib/pages/index.ts';
+import {
+  getNewOrder,
+  updateProjectLastUpdated,
+  ensureUniqueSlug,
+  trimStringToMaxLength,
+} from '@lib/pages/index.ts';
 import type { apiPagePut } from '@ty/api.ts';
 import type { Page } from '@ty/Types.ts';
 import type { APIRoute, AstroCookies } from 'astro';
@@ -60,6 +65,13 @@ export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
   const oldPage = JSON.parse(
     readFile(`/data/pages/${pageUuid}.json`) as string
   ) as Page;
+
+  if (oldPage.title !== page.title) {
+    const maxTitle = trimStringToMaxLength(body.page?.title as string, 20);
+    const pageSlug = ensureUniqueSlug(maxTitle, context);
+
+    page.slug = pageSlug;
+  }
 
   writeFile(`/data/pages/${pageUuid}.json`, JSON.stringify(page, null, 2));
 

--- a/src/pages/api/projects/[projectName]/pages/index.ts
+++ b/src/pages/api/projects/[projectName]/pages/index.ts
@@ -70,8 +70,7 @@ export const POST: APIRoute = async ({
 
   const uuid = uuidv4();
 
-  const maxTitle = trimStringToMaxLength(body.page?.title as string, 20);
-  const pageSlug = ensureUniqueSlug(maxTitle, context);
+  const pageSlug = ensureUniqueSlug(body.page?.title as string, context);
 
   const newPage = {
     ...page,

--- a/src/pages/api/projects/[projectName]/pages/index.ts
+++ b/src/pages/api/projects/[projectName]/pages/index.ts
@@ -2,7 +2,12 @@ import { gitRepo } from '@backend/gitRepo.ts';
 import { getPageData, getRepositoryUrl } from '@backend/projectHelpers.ts';
 import { userInfo } from '@backend/userInfo.ts';
 import { initFs } from '@lib/memfs/index.ts';
-import { getNewOrder, updateProjectLastUpdated } from '@lib/pages/index.ts';
+import {
+  ensureUniqueSlug,
+  getNewOrder,
+  trimStringToMaxLength,
+  updateProjectLastUpdated,
+} from '@lib/pages/index.ts';
 import type { apiPagePost } from '@ty/api.ts';
 import type { APIRoute } from 'astro';
 import { v4 as uuidv4 } from 'uuid';
@@ -65,20 +70,18 @@ export const POST: APIRoute = async ({
 
   const uuid = uuidv4();
 
-  writeFile(
-    `/data/pages/${uuid}.json`,
-    JSON.stringify(
-      {
-        ...page,
-        created_at,
-        created_by,
-        updated_at,
-        updated_by,
-      },
-      null,
-      2
-    )
-  );
+  const maxTitle = trimStringToMaxLength(body.page?.title as string, 20);
+  const pageSlug = ensureUniqueSlug(maxTitle, context);
+
+  const newPage = {
+    ...page,
+    slug: pageSlug,
+    created_at,
+    created_by,
+    updated_at,
+    updated_by,
+  };
+  writeFile(`/data/pages/${uuid}.json`, JSON.stringify(newPage, null, 2));
 
   const { pages } = getPageData(
     fs,
@@ -104,5 +107,5 @@ export const POST: APIRoute = async ({
     });
   }
 
-  return new Response(JSON.stringify(body), { status: 200 });
+  return new Response(JSON.stringify({ page: newPage }), { status: 200 });
 };

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -122,6 +122,7 @@ export type Page = {
   created_at: string;
   created_by: string;
   title: string;
+  slug?: string;
   parent?: string;
   updated_at: string;
   updated_by: string;


### PR DESCRIPTION
# Summary

Currently we are using page UUID's for URL's.  This PR adds a slug value for each non-home page (home pages are simply the site URL).  The code uses the title of the page for custom pages, and the event label for auto-generated pages.  These are slugified and limited to 20 characters (we may revisit this limit with feedback down the road).

Note that changes will be needed for the presentation client to use these slugs. In the case where there is no `slug` value for a page, the presentation client should use the UUID.