### PR TITLE
Fix issues with long string in set dropdown for video events

### DIFF
--- a/src/apps/EventDetail/EventDetail.css
+++ b/src/apps/EventDetail/EventDetail.css
@@ -22,6 +22,10 @@
   justify-content: flex-end;
 }
 
+.event-detail .set-info-bar .set-info-bar-right .select-trigger {
+  flex-grow: 0;
+}
+
 .event-detail .add-set-button svg {
   margin: 0;
 }
@@ -331,6 +335,18 @@
   text-wrap: wrap;
 }
 
+.video-event-detail .select-container {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+  flex-flow: row-reverse;
+  gap: 10px;
+}
+
+.video-event-detail .select-trigger {
+  flex-grow: 1;
+}
+
 .video-event-detail .event-detail-table-header .header-buttons {
   display: flex;
   gap: 12px;
@@ -346,14 +362,7 @@
 }
 
 .video-event-detail .set-picker {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
   margin: 20px 0;
-}
-
-.video-event-detail .set-picker .select-trigger {
-  margin-top: 10px;
 }
 
 .video-event-detail .set-picker h3 {

--- a/src/apps/EventDetail/VideoDisplay.tsx
+++ b/src/apps/EventDetail/VideoDisplay.tsx
@@ -41,8 +41,15 @@ export const VideoDisplay: React.FC<EventDisplayProps> = (props) => {
         <div className='annotations-pane'>
           <div className='annotations-pane-header'>
             <div className='set-picker'>
+              <h3>{t['Annotations']}</h3>
               <div className='select-container'>
-                <h3>{t['Annotations']}</h3>
+                <Button
+                  className='outline add-set-button'
+                  onClick={() => props.stateHandlers.setShowAddSetModal(true)}
+                >
+                  {t['Add Set']}
+                  <PlusIcon />
+                </Button>
                 {props.sets.length > 1 && (
                   <SetSelect
                     onChange={(uuid) =>
@@ -56,13 +63,6 @@ export const VideoDisplay: React.FC<EventDisplayProps> = (props) => {
                   />
                 )}
               </div>
-              <Button
-                className='outline add-set-button'
-                onClick={() => props.stateHandlers.setShowAddSetModal(true)}
-              >
-                {t['Add Set']}
-                <PlusIcon />
-              </Button>
             </div>
             <AnnotationTableHeader
               displayAnnotations={props.displayAnnotations}

--- a/src/components/Formic/Formic.css
+++ b/src/components/Formic/Formic.css
@@ -317,6 +317,14 @@
   padding: 8px 14px 8px 14px;
   position: relative;
   user-select: none;
+  width: 100%;
+}
+
+.select-item * {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 10px;
 }
 
 .select-item[data-disabled] {


### PR DESCRIPTION
# Summary

- adds `flex-grow: 1` to the set dropdown on the video event page so it fills the width available to it, instead of being sized dynamically based on the currently selected set
- adds styling to limit dropdown item text to one line and truncate any overflow with an ellipses