### PR TITLE
Fix for importing manifest 

### DIFF
--- a/src/lib/iiif/import.ts
+++ b/src/lib/iiif/import.ts
@@ -108,7 +108,7 @@ export const importIIIFManifest = async (
           const annotations: AnnotationEntry[] = [];
           const label = getLabel(a.label);
           let anno: IIIFAnnotationPage | undefined = undefined;
-          if (a.id.endsWith('.json')) {
+          if (a.id.endsWith('.json') && !a.items) {
             const annoResult = await fetch(a.id);
             if (annoResult.ok) {
               anno = await annoResult.json();
@@ -155,6 +155,7 @@ export const importIIIFManifest = async (
               }
             });
           }
+          console.log('Annotations: ', annotations);
           result.annotations.push({
             id: annoFileId,
             annotation: {


### PR DESCRIPTION
# Summary

This small hack allows imports of manifests generated by AVA.  The AVA code will be updated to not require this fix, but the code will still work as expected.