### PR TITLE
Add visibility options

### DIFF
--- a/src/apps/NewProject/NewProject.tsx
+++ b/src/apps/NewProject/NewProject.tsx
@@ -44,7 +44,8 @@ export const NewProject = (props: NewProjectProps) => {
       additionalUsers: project.additional_users.map((u) => u.login_name),
       language: project.language,
       autoPopulateHomePage: project.auto_populate_home_page,
-      visibility: 'public',
+      visibility: project.is_private ? 'private' : 'public',
+      generate_pages_site: !!project.generate_pages_site,
       tags: project.tags
         ? // @ts-ignore
           mapTagData(project!.tags.data, map)

--- a/src/components/Formic/index.tsx
+++ b/src/components/Formic/index.tsx
@@ -223,6 +223,68 @@ export const SelectInput = (props: SelectInputProps) => {
   );
 };
 
+interface DoubleSwitchInputProps {
+  label: string;
+  helperText?: string;
+  name: string;
+  optionLeft: { label: string; value: string; disabled?: boolean };
+  optionRight: { label: string; value: string; disabled?: boolean };
+  required?: boolean;
+  bottomNote?: string;
+}
+
+export const DoubleSwitchInput = (props: DoubleSwitchInputProps) => {
+  const [_field, meta, helpers] = useField(props.name);
+
+  const { value } = meta;
+  const { setValue } = helpers;
+  return (
+    <div>
+      <div className='av-label-bold formic-form-label'>
+        {props.label}
+        {props.required && <Required />}
+      </div>
+      {props.helperText && (
+        <div className='av-label formic-form-helper-text'>
+          {props.helperText}
+        </div>
+      )}
+      <div className='formic-form-switch'>
+        <Button
+          type='button'
+          className={
+            value === props.optionLeft.value
+              ? 'unstyled formic-form-switch-button formic-form-switch-button-left formic-form-switch-button-selected'
+              : 'unstyled formic-form-switch-button formic-form-switch-button-left'
+          }
+          onClick={() => setValue(props.optionLeft.value)}
+          disabled={props.optionLeft.disabled}
+        >
+          {props.optionLeft.label}
+        </Button>
+        <Button
+          type='button'
+          className={
+            value === props.optionRight.value
+              ? 'unstyled formic-form-switch-button formic-form-switch-button-right formic-form-switch-button-selected'
+              : 'unstyled formic-form-switch-button formic-form-switch-button-right'
+          }
+          onClick={() => setValue(props.optionRight.value)}
+          disabled={props.optionRight.disabled}
+        >
+          {props.optionRight.label}
+        </Button>
+      </div>
+      <ErrorMessage name={props.name} component='div' />
+      {props.bottomNote && (
+        <div className='av-label-italic formic-form-helper-text'>
+          {props.bottomNote}
+        </div>
+      )}
+    </div>
+  );
+};
+
 interface TripleSwitchInputProps {
   label: string;
   helperText?: string;

--- a/src/components/ProjectForm/EditProjectForm.tsx
+++ b/src/components/ProjectForm/EditProjectForm.tsx
@@ -1,6 +1,11 @@
-import type { ProjectData, Translations, UserInfo } from '@ty/Types.ts';
-import { Formik, Form } from 'formik';
-import { TextInput, UserList } from '@components/Formic/index.tsx';
+import type {
+  ProjectData,
+  Translations,
+  UserInfo,
+  Project,
+} from '@ty/Types.ts';
+import { Formik, Form, useFormikContext } from 'formik';
+import { TextInput, UserList, ToggleInput } from '@components/Formic/index.tsx';
 import { useEffect, useRef, useMemo } from 'react';
 
 import './ProjectForm.css';
@@ -29,6 +34,17 @@ const FormContents = (props: EditProjectFormProps) => {
   const generalRef = useRef(null);
   const userRef = useRef(null);
 
+  const { values, setFieldValue } = useFormikContext();
+
+  useEffect(() => {
+    if (
+      (values as Project).is_private &&
+      (values as Project).generate_pages_site
+    ) {
+      setFieldValue('generate_pages_site', false);
+    }
+  }, [values]);
+
   useEffect(() => {
     const executeScroll = (ref: React.MutableRefObject<HTMLElement | null>) =>
       ref.current!.scrollIntoView();
@@ -46,6 +62,17 @@ const FormContents = (props: EditProjectFormProps) => {
         <Form>
           <h2>{t['General']}</h2>
           <div ref={generalRef} />
+          <ToggleInput
+            label={t['Use Private Repository']}
+            name='is_private'
+            helperText={t['_private_repository_helper_text_']}
+          />
+
+          <ToggleInput
+            label={t['Generate GitHub Pages Site']}
+            name='generate_pages_site'
+            helperText={t['_generate_pages_site_helper_text_']}
+          />
 
           <TextInput
             label={t['Title']}
@@ -111,6 +138,10 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = (props) => {
       media_player: props.projectData.project.media_player,
       authors: props.projectData.project.authors,
       title: props.projectData.project.title,
+      is_private: !!props.projectData.project.is_private,
+      generate_pages_site:
+        props.projectData.project.generate_pages_site ||
+        props.projectData.publish.publish_pages_app,
     };
   }, [props.projectData]);
 

--- a/src/components/ProjectForm/Fields.tsx
+++ b/src/components/ProjectForm/Fields.tsx
@@ -1,4 +1,4 @@
-import { TripleSwitchInput } from '@components/Formic/index.tsx';
+import { DoubleSwitchInput } from '@components/Formic/index.tsx';
 import type { Translations } from '@ty/Types.ts';
 
 interface MediaPlayerFieldProps {
@@ -6,17 +6,12 @@ interface MediaPlayerFieldProps {
 }
 
 export const MediaPlayerField: React.FC<MediaPlayerFieldProps> = (props) => (
-  <TripleSwitchInput
+  <DoubleSwitchInput
     label={props.i18n.t['Media Player']}
     name='media_player'
     optionLeft={{
       value: 'avannotate',
       label: props.i18n.t['AV Annotate Viewer'],
-    }}
-    optionMiddle={{
-      value: 'universal',
-      label: props.i18n.t['Universal Viewer'],
-      disabled: true,
     }}
     optionRight={{ value: 'aviary', label: props.i18n.t['Aviary Player'] }}
     required

--- a/src/components/ProjectForm/NewProjectForm.tsx
+++ b/src/components/ProjectForm/NewProjectForm.tsx
@@ -1,5 +1,5 @@
 import type { GitHubOrganization, Project, Translations } from '@ty/Types.ts';
-import { Formik, Form } from 'formik';
+import { Formik, Form, useFormikContext } from 'formik';
 import {
   TextInput,
   SelectInput,
@@ -43,6 +43,8 @@ const FormContents = (props: NewProjectFormProps) => {
 
   const emptyProject: Project = {
     github_org: props.orgs[0].orgName,
+    is_private: false,
+    generate_pages_site: true,
     title: '',
     description: '',
     language: 'en',
@@ -110,123 +112,148 @@ const FormContents = (props: NewProjectFormProps) => {
             setSubmitting(false);
           }}
         >
-          {({ isValid }) => (
-            <Form>
-              <h2>{t['General']}</h2>
-              <div ref={generalRef} />
-              <SelectInput
-                label={t['GitHub Organization']}
-                name='github_org'
-                options={props.orgs.map((o) => ({
-                  value: o.orgName,
-                  label: o.orgName,
-                }))}
-                required
-              />
+          {({ isValid, setFieldValue, values }) => {
+            if (
+              (values as Project).is_private &&
+              (values as Project).generate_pages_site
+            ) {
+              setFieldValue('generate_pages_site', false);
+            }
 
-              <TextInput
-                label={t['Title']}
-                helperText={
-                  t[
-                    'A title that will show up at the top of your project pages.'
-                  ]
-                }
-                name='title'
-                required
-              />
+            return (
+              <Form>
+                <h2>{t['General']}</h2>
+                <div ref={generalRef} />
+                <SelectInput
+                  label={t['GitHub Organization']}
+                  name='github_org'
+                  options={props.orgs.map((o) => ({
+                    value: o.orgName,
+                    label: o.orgName,
+                  }))}
+                  required
+                />
 
-              <TextInput
-                label={t['Description']}
-                helperText={t['A brief paragraph describing your project.']}
-                name='description'
-                isLarge
-                required
-              />
+                <ToggleInput
+                  label={t['Use Private Repository']}
+                  name='is_private'
+                  helperText={t['_private_repository_helper_text_']}
+                />
 
-              <SelectInput
-                label={t['Language']}
-                name='language'
-                options={countryOptions}
-                required
-              />
+                <ToggleInput
+                  label={t['Generate GitHub Pages Site']}
+                  name='generate_pages_site'
+                  helperText={t['_generate_pages_site_helper_text_']}
+                />
 
-              <TextInput
-                label={t['Project Slug']}
-                helperText={
-                  t[
-                    'A short name used in URLs for your project which will be the repository name used on GitHub.'
-                  ]
-                }
-                name='slug'
-                required
-                bottomNote={
-                  t[
-                    'Please do not use spaces or punctuation other than hyphens.'
-                  ]
-                }
-              />
+                <TextInput
+                  label={t['Title']}
+                  helperText={
+                    t[
+                      'A title that will show up at the top of your project pages.'
+                    ]
+                  }
+                  name='title'
+                  required
+                />
 
-              <TextInput
-                label={t['Project Author(s)']}
-                helperText={
-                  t[
-                    'Names will appear at the bottom of your project pages. If left blank, the project owners GitHub username will show instead.'
-                  ]
-                }
-                name='authors'
-              />
+                <TextInput
+                  label={t['Description']}
+                  helperText={t['A brief paragraph describing your project.']}
+                  name='description'
+                  isLarge
+                  required
+                />
 
-              <MediaPlayerField i18n={props.i18n} />
+                <SelectInput
+                  label={t['Language']}
+                  name='language'
+                  options={countryOptions}
+                  required
+                />
 
-              <ToggleInput
-                label={t['Auto-populate Home page']}
-                helperText=''
-                name='auto_populate_home_page'
-              />
+                <TextInput
+                  label={t['Project Slug']}
+                  helperText={
+                    t[
+                      'A short name used in URLs for your project which will be the repository name used on GitHub.'
+                    ]
+                  }
+                  name='slug'
+                  required
+                  bottomNote={
+                    t[
+                      'Please do not use spaces or punctuation other than hyphens.'
+                    ]
+                  }
+                />
 
-              <div className='project-form-divider' />
-              <div ref={userRef} />
-              <UserList
-                label={t['Additional Users (optional)']}
-                name='additional_users'
-                addString={t['add']}
-                nameString={t['User GitHub Name']}
-                i18n={props.i18n}
-              />
+                <TextInput
+                  label={t['Project Author(s)']}
+                  helperText={
+                    t[
+                      'Names will appear at the bottom of your project pages. If left blank, the project owners GitHub username will show instead.'
+                    ]
+                  }
+                  name='authors'
+                />
 
-              <div className='project-form-divider' />
+                <MediaPlayerField i18n={props.i18n} />
 
-              <div ref={tagRef} />
-              <h2>{t['Tags (optional)']}</h2>
-              <div className='av-label'>
-                {
-                  t[
-                    'Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.'
-                  ]
-                }
-              </div>
-              <SpreadsheetInput
-                accept='.tsv, .csv, .xlsx, .txt'
-                i18n={props.i18n}
-                label={t['Tags File']}
-                name='tags'
-                importAsOptions={importAsOptions}
-              />
+                <ToggleInput
+                  label={t['Auto-populate Home page']}
+                  helperText=''
+                  name='auto_populate_home_page'
+                />
 
-              <BottomBar>
-                <div className='project-form-actions-container'>
-                  <Button className='primary' type='submit' disabled={!isValid}>
-                    {t['Create Project']}
-                  </Button>
-                  <a href={`/${props.i18n.lang}/projects`}>
-                    <Button type='submit' className='outline'>
-                      {t['cancel']}
-                    </Button>
-                  </a>
+                <div className='project-form-divider' />
+                <div ref={userRef} />
+                <UserList
+                  label={t['Additional Users (optional)']}
+                  name='additional_users'
+                  addString={t['add']}
+                  nameString={t['User GitHub Name']}
+                  i18n={props.i18n}
+                />
+
+                <div className='project-form-divider' />
+
+                <div ref={tagRef} />
+                <h2>{t['Tags (optional)']}</h2>
+                <div className='av-label'>
+                  {
+                    t[
+                      'Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.'
+                    ]
+                  }
                 </div>
-              </BottomBar>
-            </Form>
-          )}
+                <SpreadsheetInput
+                  accept='.tsv, .csv, .xlsx, .txt'
+                  i18n={props.i18n}
+                  label={t['Tags File']}
+                  name='tags'
+                  importAsOptions={importAsOptions}
+                />
+
+                <BottomBar>
+                  <div className='project-form-actions-container'>
+                    <Button
+                      className='primary'
+                      type='submit'
+                      disabled={!isValid}
+                    >
+                      {t['Create Project']}
+                    </Button>
+                    <a href={`/${props.i18n.lang}/projects`}>
+                      <Button type='submit' className='outline'>
+                        {t['cancel']}
+                      </Button>
+                    </a>
+                  </div>
+                </BottomBar>
+              </Form>
+            );
+          }}
         </Formik>
       </div>
     </div>

--- a/src/i18n/en/new-project.json
+++ b/src/i18n/en/new-project.json
@@ -33,5 +33,9 @@
   "Tag Category": "Tag Category",
   "Import file contains column headers?": "Import file contains column headers?",
   "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.": "Tags are labels used in the interface to index, organize, and discover topics in the annotations. Categories can be used to organize the tags in groups.",
-  "Project Slug should only contain alphanumeric characters and hyphens.": "Project Slug should only contain alphanumeric characters and hyphens."
+  "Project Slug should only contain alphanumeric characters and hyphens.": "Project Slug should only contain alphanumeric characters and hyphens.",
+  "Use Private Repository": "Use Private Repository",
+  "_private_repository_helper_text_": "Private repositories do not generate GitHub Pages sites. Instead they will generate a static site and check it into your project repository.",
+  "Generate GitHub Pages Site": "Generate GitHub Pages Site",
+  "_generate_pages_site_helper_text_": "Generate a GitHub Pages site.  If unchecked a static site which you can deploy will be created and checked into your project repository."
 }

--- a/src/lib/GitHub/index.ts
+++ b/src/lib/GitHub/index.ts
@@ -333,3 +333,22 @@ export const getRepo = async (
     },
   });
 };
+
+export const changeRepoVisibility = async (
+  token: string,
+  org: string,
+  slug: string,
+  isPrivate: boolean
+): Promise<Response> => {
+  return await fetch(`https://api.github.com/repos/${org}/${slug}`, {
+    method: 'PATCH',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      private: isPrivate,
+    }),
+  });
+};

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -42,6 +42,8 @@ export type MediaPlayer = 'avannotate' | 'universal' | 'aviary';
 
 export type Project = {
   github_org: string;
+  is_private?: boolean;
+  generate_pages_site?: boolean;
   title: string;
   description: string;
   language: string;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -30,7 +30,8 @@ export type apiAnnotationSetPost = {
 export type apiProjectsProjectNamePost = {
   templateRepo: string;
   description: string;
-  visibility?: 'private' | 'public'; // Defaults to private
+  visibility: 'private' | 'public';
+  generate_pages_site: boolean;
   title: string;
   slug: string;
   gitHubOrg: string;
@@ -98,6 +99,8 @@ export type apiProjectPut = {
   media_player: MediaPlayer;
   title: string;
   tags?: Tags;
+  is_private: boolean;
+  generate_pages_site: boolean;
 };
 
 export type apiAnalyzeManifest = {


### PR DESCRIPTION
# Summary

- Adds the option to make a repository Private on the New Project form and the Project Setting form.  This automatically disables GitHub Pages deployment.
- Adds the option to disable GitHub Pages site deployment on the New Project form and the Project Setting form.

![image](https://github.com/user-attachments/assets/5147755b-468e-47ee-9909-7acd1fc39237)
