### PR TITLE
Changed sets dropdown to use AV File label

### DIFF
--- a/src/apps/AnnotationImport/AnnotationImport.tsx
+++ b/src/apps/AnnotationImport/AnnotationImport.tsx
@@ -98,7 +98,9 @@ export const AnnotationImportForm: React.FC<Props> = (props) => {
         )
         .map((uuid) => ({
           label: `${
-            props.project.events[props.project.annotations[uuid].event_id].label
+            props.project.events[props.project.annotations[uuid].event_id]
+              .audiovisual_files[props.project.annotations[uuid].source_id]
+              .label
           } - ${props.project.annotations[uuid].set}`,
           value: uuid,
         })),


### PR DESCRIPTION
# Summary

This PR changes the Sets dropdown in Import Annotations to use the AV File label instead of the event label.

![image](https://github.com/user-attachments/assets/3f994753-4237-4d6a-ba84-216785786daa)
