### PR TITLE
`deserialize` fixes for BR and I tags

### DIFF
--- a/src/lib/slate/deserialize.ts
+++ b/src/lib/slate/deserialize.ts
@@ -17,7 +17,7 @@ export const deserialize = (
   el: DocumentFragment | ChildNode,
   markAttributes: { [key: string]: boolean } = {}
 ): any => {
-  if (el.nodeType === Node.TEXT_NODE) {
+  if (el.nodeType === Node.TEXT_NODE || el.nodeName === 'BR') {
     return jsx('text', markAttributes, el.textContent);
   } else if (
     el.nodeType !== Node.DOCUMENT_FRAGMENT_NODE &&
@@ -38,6 +38,9 @@ export const deserialize = (
       nodeAttributes.italic = true;
       break;
     case 'ITALIC':
+      nodeAttributes.italic = true;
+      break;
+    case 'I':
       nodeAttributes.italic = true;
       break;
     case 'STRONG':


### PR DESCRIPTION
# Summary

This PR updates the `deserialize` function, which is used to convert HTML to Slate nodes, to fix a couple issues:

* treat `<br>` as a text node, converting it to `{ text: '' }`, which is identical to the way our rich text component represents empty lines
* interpret `<i>` as italic, in addition to `<italic>`