### PR TITLE
Remove another spot in `deserialize` where `"/n"` was returned for `<br>` elements

### DIFF
--- a/src/lib/slate/deserialize.ts
+++ b/src/lib/slate/deserialize.ts
@@ -58,8 +58,6 @@ export const deserialize = (
   switch (el.nodeName) {
     case 'BODY':
       return jsx('fragment', {}, children);
-    case 'BR':
-      return '\n';
     case 'BLOCKQUOTE':
       return jsx('element', { type: 'quote' }, children);
     case 'P':


### PR DESCRIPTION
# Summary

This PR removes a case in the switch statement that was still trying to return the bad newline node. This case isn't actually reachable since the first `if` statement in the function will return, so we're just removing some dead code here.