### PR TITLE
Properly support line breaks

### DIFF
--- a/src/lib/slate/deserialize.ts
+++ b/src/lib/slate/deserialize.ts
@@ -17,7 +17,7 @@ export const deserialize = (
   el: DocumentFragment | ChildNode,
   markAttributes: { [key: string]: boolean } = {}
 ): any => {
-  if (el.nodeType === Node.TEXT_NODE || el.nodeName === 'BR') {
+  if (el.nodeType === Node.TEXT_NODE) {
     return jsx('text', markAttributes, el.textContent);
   } else if (
     el.nodeType !== Node.DOCUMENT_FRAGMENT_NODE &&
@@ -60,6 +60,8 @@ export const deserialize = (
       return jsx('fragment', {}, children);
     case 'BLOCKQUOTE':
       return jsx('element', { type: 'quote' }, children);
+    case 'BR':
+      return jsx('element', { type: 'line-break' }, children);
     case 'P':
       return jsx('element', { type: 'paragraph' }, children);
     case 'A':

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -41,6 +41,8 @@ export const Element = ({
           {children}
         </h2>
       );
+    case 'line-break':
+      return <br contentEditable={false} />;
     case 'list-item':
       return (
         <li style={style} {...attributes}>


### PR DESCRIPTION
# Summary

This PR adds a new `line-break` Slate node element that is rendered as a `<br>` element. This can't be added via the rich text editor (you can just press enter and create a new paragraph) but it helps us support imported HTML that uses `<br>` elements.