### PR TITLE
Fix Slate node for imported event descriptions

### DIFF
--- a/src/apps/EventImport/EventImport.tsx
+++ b/src/apps/EventImport/EventImport.tsx
@@ -18,8 +18,6 @@ import { LoadingOverlay } from '@components/LoadingOverlay/LoadingOverlay.tsx';
 import { deserialize } from '@lib/slate/deserialize.ts';
 import { getFileDuration } from '@lib/events/index.ts';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Text } from 'slate';
-import { emptyParagraph } from '@lib/slate/index.tsx';
 
 interface Props {
   i18n: Translations;
@@ -133,12 +131,12 @@ export const FormContents: React.FC<FormContentsProps> = (props) => {
         const template = document.createElement('description');
         template.innerHTML = ev.description as unknown as string;
 
-        const descNode = deserialize(template);
-
-        if (Text.isText(descNode)) {
-          const paragraph = structuredClone(emptyParagraph);
-          paragraph[0].children = [descNode];
-        }
+        ev.description = [
+          {
+            type: 'paragraph',
+            children: deserialize(template),
+          },
+        ];
       }
 
       for await (const afUuid of Object.keys(ev.audiovisual_files)) {

--- a/src/apps/EventImport/EventImport.tsx
+++ b/src/apps/EventImport/EventImport.tsx
@@ -18,6 +18,8 @@ import { LoadingOverlay } from '@components/LoadingOverlay/LoadingOverlay.tsx';
 import { deserialize } from '@lib/slate/deserialize.ts';
 import { getFileDuration } from '@lib/events/index.ts';
 import * as Dialog from '@radix-ui/react-dialog';
+import { Text } from 'slate';
+import { emptyParagraph } from '@lib/slate/index.tsx';
 
 interface Props {
   i18n: Translations;
@@ -130,7 +132,13 @@ export const FormContents: React.FC<FormContentsProps> = (props) => {
       if (ev.description) {
         const template = document.createElement('description');
         template.innerHTML = ev.description as unknown as string;
-        ev.description = deserialize(template);
+
+        const descNode = deserialize(template);
+
+        if (Text.isText(descNode)) {
+          const paragraph = structuredClone(emptyParagraph);
+          paragraph[0].children = [descNode];
+        }
       }
 
       for await (const afUuid of Object.keys(ev.audiovisual_files)) {

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -3,7 +3,7 @@ import {
   EmbeddedEventComparison,
 } from '@components/EmbeddedEvent/index.ts';
 import { getTranslationsFromUrl } from '@i18n';
-import { Node, Text, type Descendant } from 'slate';
+import { type Element as SlateElement, Node, Text } from 'slate';
 
 export const Element = ({
   attributes,
@@ -206,7 +206,7 @@ export const serialize = (nodes: Node[]) => {
   });
 };
 
-export const emptyParagraph: Descendant[] = [
+export const emptyParagraph: SlateElement[] = [
   {
     type: 'paragraph',
     children: [{ text: '' }],


### PR DESCRIPTION
# Summary

This PR fixes an issue with the deserialization of event descriptions in the event import component. Plain text descriptions were being deserialized as text nodes, which our rich text editor doesn't like. The fix is to automatically wrap them in a `paragraph` node.