### PR TITLE
Fix for switching back and forth between generate site

### DIFF
--- a/src/apps/Project/Project.css
+++ b/src/apps/Project/Project.css
@@ -12,6 +12,9 @@
 
 .project-container .project-top-bar .project-title {
   font-size: 24px;
+  gap: 5px;
+  display: flex;
+  flex-direction: row;
 }
 
 .project-container .project-top-bar .project-top-bar-buttons {

--- a/src/apps/Project/Project.tsx
+++ b/src/apps/Project/Project.tsx
@@ -22,11 +22,12 @@ import './Project.css';
 import { PageList } from '@components/PageList/index.ts';
 import { Tabs } from '@components/Tabs/Tabs.tsx';
 import { Table } from '@components/Table/Table.tsx';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DeleteEventModal } from '@components/DeleteEventModal/DeleteEventModal.tsx';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Chats } from '@phosphor-icons/react/dist/icons/Chats';
 import { exportEvents } from '@lib/events/export.ts';
+import { BuildStatus } from '@components/BuildStatus/BuildStatus.tsx';
 
 interface Props {
   i18n: Translations;
@@ -54,10 +55,6 @@ export const Project: React.FC<Props> = (props) => {
     [props.project.events]
   );
 
-  const handleNavToSets = () => {
-    window.location.pathname = `/${lang}/projects/${props.projectSlug}/sets`;
-  };
-
   const handleNavToSettings = () => {
     window.location.pathname = `/${lang}/projects/${props.projectSlug}/settings`;
   };
@@ -82,7 +79,10 @@ export const Project: React.FC<Props> = (props) => {
       />
       <div className='project-container'>
         <div className='project-top-bar'>
-          <h2 className='project-title'>{props.project.project.title}</h2>
+          <h2 className='project-title'>
+            {props.project.project.title}
+            <BuildStatus projectSlug={props.projectSlug} i18n={props.i18n} />
+          </h2>
           <div className='project-top-bar-buttons'>
             <a href={`/${lang}/projects/${props.projectSlug}/tags`}>
               <Button className='primary'>

--- a/src/components/BuildStatus/BuildStatus.css
+++ b/src/components/BuildStatus/BuildStatus.css
@@ -1,0 +1,27 @@
+.build-status-spinner {
+  color: var(--primary);
+}
+
+.build-status-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.rightTI {
+  white-space: nowrap;
+  overflow: hidden;
+  animation: marquee 10s linear infinite;
+}
+.rightTI:hover {
+  animation-play-state: paused;
+}
+@keyframes marquee {
+  0% {
+    text-indent: 100%;
+  }
+  100% {
+    text-indent: -100%;
+  }
+}

--- a/src/components/BuildStatus/BuildStatus.tsx
+++ b/src/components/BuildStatus/BuildStatus.tsx
@@ -1,0 +1,52 @@
+import { Spinner } from '@components/Spinner/Spinner.tsx';
+import type { Translations } from '@ty/Types.ts';
+import { useState, useEffect, useMemo } from 'react';
+import './BuildStatus.css';
+
+interface BuildStatusProps {
+  projectSlug: string;
+  i18n: Translations;
+}
+
+export const BuildStatus = (props: BuildStatusProps) => {
+  const [building, setBuilding] = useState(false);
+
+  const { t } = props.i18n;
+
+  const sendStatusRequest = () => {
+    fetch(`/api/projects/${props.projectSlug}/status`).then((result) => {
+      if (result.ok) {
+        return result.json().then((data) => {
+          if (data.running_count > 0) {
+            setBuilding(true);
+          } else {
+            setBuilding(false);
+          }
+        });
+      }
+      setBuilding(false);
+    });
+  };
+
+  const interval = useMemo(() => {
+    return setInterval(sendStatusRequest, 10000);
+  }, []);
+
+  useEffect(() => {
+    sendStatusRequest();
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (building) {
+    return (
+      <div className='build-status-container'>
+        <Spinner className='build-status-spinner' />
+        <div className='av-label-bold rightTI li'>{t['Site Building']}</div>
+      </div>
+    );
+  } else {
+    return <div />;
+  }
+};

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -17,7 +17,7 @@ export const Spinner = (props: SpinnerProps) => {
       className={props.className ? `${props.className} spinner` : 'spinner'}
       style={{ width }}
     >
-      <circle cx='50' cy='50' r='45' />
+      <circle cx='50' cy='50' r='45' fill='inherit' />
     </svg>
   );
 };

--- a/src/i18n/en/projects.json
+++ b/src/i18n/en/projects.json
@@ -23,5 +23,6 @@
   "event": "Event",
   "Last Edited": "Last Edited",
   "Invited": "Invited",
-  "Loading Your Projects": "Loading Your Projects"
+  "Loading Your Projects": "Loading Your Projects",
+  "Site Building": "Site Building"
 }

--- a/src/lib/GitHub/index.ts
+++ b/src/lib/GitHub/index.ts
@@ -180,12 +180,32 @@ export const createRepositoryFromTemplate = async (
 
 export const addRepositoryHomepage = async (
   org: string,
-  token: string,
   repoName: string,
+  token: string,
   homePageURL: string
 ): Promise<Response> => {
   const body = {
     homepage: homePageURL,
+  };
+
+  return await fetch(`https://api.github.com/repos/${org}/${repoName}`, {
+    method: 'PATCH',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify(body),
+  });
+};
+
+export const removeRepositoryHomepage = async (
+  org: string,
+  repoName: string,
+  token: string
+): Promise<Response> => {
+  const body = {
+    homepage: '',
   };
 
   return await fetch(`https://api.github.com/repos/${org}/${repoName}`, {
@@ -220,6 +240,21 @@ export const enablePages = async (
       'X-GitHub-Api-Version': '2022-11-28',
     },
     body: JSON.stringify(body),
+  });
+};
+
+export const disablePages = async (
+  org: string,
+  repo: string,
+  token: string
+): Promise<Response> => {
+  return await fetch(`https://api.github.com/repos/${org}/${repo}/pages`, {
+    method: 'DELETE',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
   });
 };
 
@@ -351,4 +386,22 @@ export const changeRepoVisibility = async (
       private: isPrivate,
     }),
   });
+};
+
+export const checkWorkflowStatus = async (
+  token: string,
+  org: string,
+  slug: string
+): Promise<Response> => {
+  return await fetch(
+    `https://api.github.com/repos/${org}/${slug}/actions/workflows/deploy-main.yml/runs?status=in_progress`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
 };

--- a/src/pages/api/projects/[projectName]/status.ts
+++ b/src/pages/api/projects/[projectName]/status.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+import { userInfo } from '@backend/userInfo.ts';
+import { checkWorkflowStatus } from '@lib/GitHub/index.ts';
+import { parseSlug } from '@backend/projectHelpers.ts';
+
+export const GET: APIRoute = async ({ cookies, params, redirect }) => {
+  const token = cookies.get('access-token');
+
+  // Get the user info
+  const info = await userInfo(cookies);
+
+  if (!token || !info) {
+    redirect('/', 307);
+  }
+
+  // Get params
+  const { projectName } = params;
+
+  const { org, repo } = parseSlug(projectName as string);
+
+  const result = await checkWorkflowStatus(info?.token as string, org, repo);
+
+  if (result.ok) {
+    const body = await result.json();
+
+    return new Response(JSON.stringify({ running_count: body.total_count }), {
+      status: 200,
+    });
+  }
+
+  return new Response(null, { status: 500 });
+};


### PR DESCRIPTION
# Summary

- Addresses: https://github.com/AVAnnotate/admin-client/issues/200
- Does not add a homepage link for sites that do not publish
- removes homepage link when site is switched from published to static
- Adds an indicator to the project page that a project is building