### PR TITLE
Fix pasting text from inside column

### DIFF
--- a/src/components/PageForm/PageForm.css
+++ b/src/components/PageForm/PageForm.css
@@ -44,7 +44,7 @@
 }
 
 .page-form .slate-column {
-  border: 1px solid var(--gray-400);
+  outline: 1px solid var(--gray-400);
 }
 
 .page-form .slate-column:last-child {


### PR DESCRIPTION
# Summary

This PR addresses the second half of #196.

This bug was an odd one because because it turned out to be Slate working as intended: https://github.com/ianstormtaylor/slate/pull/4489

We don't want that behavior, so this PR adds a new editor plugin that overrides the `insertNodes` behavior in this situation to only insert the contents of the column that's been copied, instead of trying to replicate the entire grid -> column -> content tree.