### PR TITLE
More rich text editor column fixes

### DIFF
--- a/src/components/Formic/SlateInput/SlateInput.tsx
+++ b/src/components/Formic/SlateInput/SlateInput.tsx
@@ -243,12 +243,15 @@ const withColumnsPlugin = (editor: BaseEditor & ReactEditor) => {
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;
 
+    // @ts-ignore
     if (node.type === 'grid') {
       const parentPath = Path.parent(path);
 
+      // @ts-ignore
       if (node.children.length === 1) {
         Transforms.removeNodes(editor, { at: path });
 
+        // @ts-ignore
         const singleColumn = node.children[0];
 
         if (singleColumn.children && singleColumn.children.length > 0) {
@@ -280,7 +283,7 @@ interface Props {
 }
 
 export const SlateInput: React.FC<Props> = (props) => {
-  const editorRef = useRef<BaseEditor & ReactEditor>(null);
+  const editorRef = useRef<(BaseEditor & ReactEditor) | null>(null);
 
   if (!editorRef.current) {
     editorRef.current = withReact(

--- a/src/components/PageForm/PageForm.tsx
+++ b/src/components/PageForm/PageForm.tsx
@@ -65,8 +65,6 @@ const FormContents: React.FC<Props> = (props) => {
     }
   }, [(values as FormPage).parent]);
 
-  console.log(values.content);
-
   return (
     <Form className='page-form'>
       <div className='page-form-body'>


### PR DESCRIPTION
# Summary

This PR adds a new override for Slate's `normalizeNode` method that checks for `grid`s that contain only one `column`, moves their content outside the grid, and deletes the grid. In other words, the contents of the remaining column will become normal top-level content.

This PR also fixes a regression from #203 that broke numbered and bulleted list insertion (the `insertNodes` override function didn't accept the `options` object that list insertion relies on). It also moves the editor from a `useMemo` hook to a ref to avoid a Slate update bug: https://github.com/ianstormtaylor/slate/issues/4081.