### PR TITLE
Adds default event embed when autogenerate initially disabled

### DIFF
--- a/src/components/PageList/PageList.tsx
+++ b/src/components/PageList/PageList.tsx
@@ -76,6 +76,41 @@ export const PageList: React.FC<Props> = (props) => {
 
     const page = copy.pages[uuid];
     page.autogenerate.enabled = false;
+    //If there is no content in the page, pre-populate with an embed of the related event, for convenience
+    if (!page.content || !page.content.length) {
+      const eventUuid = page.autogenerate.type_id;
+      if (eventUuid) {
+        page.content = [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                text: '',
+              },
+            ],
+          },
+          {
+            //@ts-ignore
+            type: 'event',
+            uuid: eventUuid,
+            includes: ['media', 'annotations', 'description'],
+            children: [
+              {
+                text: '',
+              },
+            ],
+          },
+          {
+            type: 'paragraph',
+            children: [
+              {
+                text: '',
+              },
+            ],
+          },
+        ];
+      }
+    }
     setSaving(true);
     const res = await fetch(
       `/api/projects/${props.projectSlug}/pages/${uuid}`,


### PR DESCRIPTION
### In this PR
Updates the behavior when an event is initially changed from autogenerated to custom -- with this change, if the `content` field of the page is empty when autogeneration is disabled, it will be filled in with an embed of the related event as the default. This will hopefully help prevent user error from manually inserting the incorrect event, etc.

This relates to Issue #128 .