### PR TITLE
Updates to timestamp UI

### DIFF
--- a/src/apps/EventDetail/Player.tsx
+++ b/src/apps/EventDetail/Player.tsx
@@ -64,12 +64,12 @@ export const Player: React.FC<Props> = (props) => {
   const { t } = props.i18n;
 
   const formattedPosition = useMemo(
-    () => formatTimestamp(position),
+    () => formatTimestamp(position, false),
     [position]
   );
 
   const formattedDuration = useMemo(
-    () => formatTimestamp(duration),
+    () => formatTimestamp(duration, false),
     [duration]
   );
 

--- a/src/components/Formic/index.tsx
+++ b/src/components/Formic/index.tsx
@@ -126,11 +126,25 @@ interface TimeInputProps {
 }
 
 export const TimeInput = (props: TimeInputProps) => {
-  const valueToDisplay = useCallback((seconds: number) => {
-    return new Date((seconds || 0) * 1000).toISOString().slice(11, 19);
-  }, []);
+  const valueToDisplay = useCallback(
+    (seconds: number, minutes: number, hours: number) => {
+      return `${hours.toString().padStart(2, '0')}:${minutes
+        .toString()
+        .padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+      // return new Date((seconds || 0) * 1000).toISOString().slice(11, 19);
+    },
+    []
+  );
 
-  const [display, setDisplay] = useState(valueToDisplay(props.initialValue));
+  const initialHours = Math.floor(props.initialValue / 3600);
+  const initialMinutes = Math.floor(
+    (props.initialValue - 3600 * Math.floor(props.initialValue / 3600)) / 60
+  );
+  const initialSeconds = props.initialValue % 60;
+
+  const [display, setDisplay] = useState(
+    valueToDisplay(initialSeconds, initialMinutes, initialHours)
+  );
 
   const onChange = useCallback((event: any) => {
     const input = event.target.value.replaceAll(':', '');
@@ -148,7 +162,7 @@ export const TimeInput = (props: TimeInputProps) => {
 
       if (hours < 24) {
         const totalSeconds = seconds + minutes * 60 + hours * 3600;
-        setDisplay(valueToDisplay(totalSeconds));
+        setDisplay(valueToDisplay(seconds, minutes, hours));
 
         props.onChange(totalSeconds);
       }

--- a/src/components/Formic/index.tsx
+++ b/src/components/Formic/index.tsx
@@ -131,7 +131,6 @@ export const TimeInput = (props: TimeInputProps) => {
       return `${hours.toString().padStart(2, '0')}:${minutes
         .toString()
         .padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-      // return new Date((seconds || 0) * 1000).toISOString().slice(11, 19);
     },
     []
   );


### PR DESCRIPTION
### In this PR
Changes the display value in the `TimeInput` component to avoid confusion with converting partial inputs to actual timestamps; for example, previously if you tried to input the timestamp `6:50`, after the first two keystrokes the value would convert to `1:05` rather than `0:65`, meaning after the third keystroke you're left with a timestamp of `10:50`, which is unintended and confusing.

Also removes the milliseconds from the player display, as their existence was leading to difficulty pasting values directly from the player into the annotation editor modal due to different levels of precision.

Relevant to issues #210, #167, and https://github.com/AVAnnotate/project-client/issues/119. 