### PR TITLE
Added scroll bar to textarea input

### DIFF
--- a/src/components/Formic/Formic.css
+++ b/src/components/Formic/Formic.css
@@ -29,6 +29,7 @@
   height: 130px;
   border: 1px solid var(--gray-200);
   border-radius: 4px;
+  overflow-y: auto;
 }
 
 .formic-form-select {


### PR DESCRIPTION
### In this PR
Currently the input for e.g. annotation text doesn't scroll, so for long annotations you just end up with this: 
![image](https://github.com/user-attachments/assets/16d3fa5f-d55b-46bd-a640-4b5c5629e85f)
...which in addition to looking confusing also seems to make the `cancel` and `save` buttons unable to be clicked. This PR adds the `overflow-y: auto` style to the class `.formic-form-textarea` so that it will scroll when necessary.