### PR TITLE
Remove HTML from CSV exports

### DIFF
--- a/src/lib/events/export.ts
+++ b/src/lib/events/export.ts
@@ -1,4 +1,4 @@
-import { serialize } from '@lib/slate/index.tsx';
+import { serializeToPlainText, serialize } from '@lib/slate/index.tsx';
 import type { AnnotationEntry, Event } from '@ty/Types.ts';
 import { formatTimestamp } from './index.ts';
 import ReactDOMServer from 'react-dom/server';
@@ -26,7 +26,7 @@ export const exportAnnotations = (annos: AnnotationEntry[], event: Event) => {
         : Number.isNaN(anno.end_time)
         ? ''
         : formatTimestamp(Math.round(anno.end_time), false),
-      anno.annotation ? serializeRichText(anno.annotation) : '',
+      anno.annotation ? serializeToPlainText(anno.annotation) : '',
       anno.tags.map((t) => t.tag).join('|') || '',
     ];
 
@@ -54,7 +54,7 @@ export const exportEvents = (projectName: string, events: Event[]) => {
         event.audiovisual_files[uuid].label,
         event.audiovisual_files[uuid].file_url,
         event.citation || '',
-        event.description ? serializeRichText(event.description) : '',
+        event.description ? serializeToPlainText(event.description) : '',
       ];
 
       str += fields.map(formatField).join(',');

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -212,3 +212,7 @@ export const emptyParagraph: SlateElement[] = [
     children: [{ text: '' }],
   },
 ];
+
+export const serializeToPlainText = (nodes: Node[]) => {
+  return nodes.map((n) => Node.string(n)).join('\n');
+};


### PR DESCRIPTION
# Summary

- Addresses https://github.com/AVAnnotate/admin-client/issues/215

Removes HTML tags from CSV exports.