### PR TITLE
Fix sort and default sort

### DIFF
--- a/src/apps/Projects/Projects.tsx
+++ b/src/apps/Projects/Projects.tsx
@@ -15,6 +15,7 @@ export type Repositories = {
   repo: string;
   title: string;
   created_at: string;
+  updated_at: string;
 };
 export interface ProjectsProps {
   repos: Repositories[];
@@ -76,12 +77,13 @@ export const Projects = (props: ProjectsProps) => {
             slug: repo.repo,
             title: repo.title,
             github_org: repo.org,
-            created_at: repo.created_at,
           },
+          repo_created_at: repo.created_at,
+          repo_updated_at: repo.updated_at,
         });
       });
 
-      setProjects(all);
+      setProjects(all.sort(Sorters[sort]));
     }
   }, [props.repos]);
 

--- a/src/apps/Projects/Projects.tsx
+++ b/src/apps/Projects/Projects.tsx
@@ -1,7 +1,6 @@
-import type { AllProjects, Translations, UserInfo } from '@ty/Types.ts';
+import type { Translations, UserInfo } from '@ty/Types.ts';
 import { Plus } from '@phosphor-icons/react/Plus';
 import { Header } from './Header/Header.tsx';
-import './Projects.css';
 import { Button } from '@radix-ui/themes';
 import { useEffect, useState } from 'react';
 import { ProjectFilter } from './Header/Header.tsx';
@@ -9,7 +8,14 @@ import { ProjectsGrid } from './ProjectsGrid/ProjectsGrid.tsx';
 import { Sorters } from '@components/SortAction/index.ts';
 import type { ProjectData } from '@ty/Types.ts';
 
-export type Repositories = { org: string; repo: string; title: string };
+import './Projects.css';
+
+export type Repositories = {
+  org: string;
+  repo: string;
+  title: string;
+  created_at: string;
+};
 export interface ProjectsProps {
   repos: Repositories[];
 
@@ -23,8 +29,10 @@ export const Projects = (props: ProjectsProps) => {
 
   const [filter, setFilter] = useState(ProjectFilter.MINE);
   const [search, setSearch] = useState<string | undefined>();
-  const [sort, setSort] = useState<'Name' | 'Oldest' | 'Newest'>('Name');
+  const [sort, setSort] = useState<'Name' | 'Oldest' | 'Newest'>('Newest');
   const [projects, setProjects] = useState<ProjectData[] | undefined>();
+  const [readyCount, setReasyCount] = useState(0);
+  const [saving, setSaving] = useState(false);
 
   const handleChangeFilter = (filter: ProjectFilter) => {
     setFilter(filter);
@@ -59,6 +67,8 @@ export const Projects = (props: ProjectsProps) => {
     if (props.repos) {
       const all: ProjectData[] = [];
 
+      setSaving(true);
+
       props.repos.forEach((repo) => {
         all.push({
           // @ts-ignore
@@ -66,6 +76,7 @@ export const Projects = (props: ProjectsProps) => {
             slug: repo.repo,
             title: repo.title,
             github_org: repo.org,
+            created_at: repo.created_at,
           },
         });
       });
@@ -112,6 +123,7 @@ export const Projects = (props: ProjectsProps) => {
       {projects && (
         <ProjectsGrid
           projects={projects}
+          search={search || ''}
           i18n={props.i18n}
           filter={filter}
           userInfo={props.userInfo}

--- a/src/apps/Projects/ProjectsGrid/ProjectsGrid.tsx
+++ b/src/apps/Projects/ProjectsGrid/ProjectsGrid.tsx
@@ -10,6 +10,8 @@ interface ProjectsGridProps {
 
   filter: ProjectFilter;
 
+  search: string;
+
   userInfo: UserInfo;
 
   getProjectData(org: string, repo: string): Promise<any>;
@@ -23,6 +25,7 @@ export const ProjectsGrid = (props: ProjectsGridProps) => {
           project={p}
           i18n={props.i18n}
           filter={props.filter}
+          search={props.search}
           userInfo={props.userInfo}
           getProjectData={props.getProjectData}
           key={`${p.project.github_org}+${p.project.slug}`}

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -30,7 +30,7 @@ export const ProjectCard = (props: ProjectCardProps) => {
         )
         .then((data: ProjectData) => {
           if (data) {
-            setProject(data);
+            setProject({ ...project, ...data });
           }
         });
     }
@@ -67,14 +67,15 @@ export const ProjectCard = (props: ProjectCardProps) => {
           </div>
           <Skeleton
             loading={
-              (project.project.updated_at || project.project.created_at) ===
-              undefined
+              (project.repo_updated_at || project.repo_created_at) === undefined
             }
           >
             <div className='project-card-last-edited av-body-small-italic'>
-              {`${t['Last Edited']} ${new Date(
-                project.project.updated_at || project.project.created_at
-              ).toLocaleDateString('en-US')}`}
+              {project.repo_updated_at || project.repo_created_at
+                ? `${t['Last Edited']} ${new Date(
+                    project.repo_updated_at || project.repo_created_at
+                  ).toLocaleDateString('en-US')}`
+                : 'Unknown'}
             </div>
           </Skeleton>
         </div>

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -12,6 +12,7 @@ type ProjectCardProps = {
   i18n: Translations;
   userInfo: UserInfo;
   filter: ProjectFilter;
+  search: string;
   getProjectData(org: string, repo: string): Promise<any>;
 };
 
@@ -40,7 +41,15 @@ export const ProjectCard = (props: ProjectCardProps) => {
     (project.project.creator === props.userInfo.profile.gitHubName &&
       props.filter !== ProjectFilter.MINE) ||
     (project.project.creator !== props.userInfo.profile.gitHubName &&
-      props.filter !== ProjectFilter.SHARED)
+      props.filter !== ProjectFilter.SHARED) ||
+    (props.search &&
+      props.search.length > 0 &&
+      !project.project.title
+        .toLocaleLowerCase()
+        .includes(props.search.toLocaleLowerCase()) &&
+      !project.project.description
+        .toLocaleLowerCase()
+        .includes(props.search.toLocaleLowerCase()))
   ) {
     return <div />;
   }

--- a/src/components/SortAction/SortAction.tsx
+++ b/src/components/SortAction/SortAction.tsx
@@ -40,7 +40,7 @@ const Icons = {
 export const SortAction = (props: SortActionProps) => {
   const { t } = props.i18n;
 
-  const [sort, setSort] = useState<keyof typeof Sorters>('Name');
+  const [sort, setSort] = useState<keyof typeof Sorters>('Newest');
 
   const changeSort = (key: keyof typeof Sorters) => () => {
     setSort(key);

--- a/src/components/SortAction/SortAction.tsx
+++ b/src/components/SortAction/SortAction.tsx
@@ -25,10 +25,10 @@ export const Sorters = {
   },
 
   Newest: (a: ProjectData, b: ProjectData) =>
-    a.project.created_at < b.project.created_at ? 1 : -1,
+    a.repo_updated_at < b.repo_updated_at ? 1 : -1,
 
   Oldest: (a: ProjectData, b: ProjectData) =>
-    a.project.created_at > b.project.created_at ? 1 : -1,
+    a.repo_updated_at > b.repo_updated_at ? 1 : -1,
 };
 
 const Icons = {

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -26,6 +26,7 @@ const userRepos = repos.map((d: any) => {
     repo: d.name,
     title: d.description,
     created_at: d.created_at,
+    updated_at: d.updated_at,
   };
 });
 ---

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -21,7 +21,12 @@ if (!info) {
 const repos = await getRepos(info as UserInfo);
 
 const userRepos = repos.map((d: any) => {
-  return { org: d.owner.login, repo: d.name, title: d.description };
+  return {
+    org: d.owner.login,
+    repo: d.name,
+    title: d.description,
+    created_at: d.created_at,
+  };
 });
 ---
 

--- a/src/pages/api/projects/[projectName]/index.ts
+++ b/src/pages/api/projects/[projectName]/index.ts
@@ -227,8 +227,8 @@ export const POST: APIRoute = async ({
       created_at: new Date().toISOString(),
       created_by: info!.profile.gitHubName || '',
       title: body.title,
-      updated_at: info!.profile.gitHubName || '',
-      updated_by: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      updated_by: info!.profile.gitHubName || '',
       autogenerate: {
         enabled: body.autoPopulateHomePage,
         type: 'home',

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -154,6 +154,9 @@ export type ProjectFile = {
   users: ProviderUser[];
 
   publish: Publish;
+
+  repo_created_at: string;
+  repo_updated_at: string;
 };
 
 export type ProjectData = {


### PR DESCRIPTION
# Summary

- Addresses https://github.com/AVAnnotate/admin-client/issues/280
- Addresses https://github.com/AVAnnotate/admin-client/issues/288

Note that Newest/Oldest sorts now use updated_at instead of created_at, so Staging and Prod will not match.