### PR TITLE
Manifest label as event label

### DIFF
--- a/src/lib/iiif/import.ts
+++ b/src/lib/iiif/import.ts
@@ -112,7 +112,9 @@ export const importIIIFManifest = async (
         created_at: new Date().toISOString(),
         created_by: userName,
         item_type: avType === 'Video' ? 'Video' : 'Audio',
-        label: `Imported Event ${result.events.length + 1}`,
+        label: mani.label.en
+          ? mani.label.en[0]
+          : `Imported Event ${result.events.length + 1}`,
         updated_at: new Date().toISOString(),
         updated_by: userName,
       },


### PR DESCRIPTION
# Summary
- Addresses https://github.com/AVAnnotate/admin-client/issues/208

When ingesting a manifest as an Event, this change now uses any manifest label as the Event Label (instead of `Imported Event 1` etc.)