### PR TITLE
Fix for view menu on transferred projects

### DIFF
--- a/src/backend/projectHelpers.ts
+++ b/src/backend/projectHelpers.ts
@@ -129,8 +129,6 @@ export const getProject = async (
 
   const parsed = parseURL(htmlUrl);
 
-  console.log(parsed);
-
   const respRepo = await getRepo(
     userInfo.token,
     parsed.org,
@@ -142,6 +140,11 @@ export const getProject = async (
   let projectChanged = false;
 
   // Make sure the project file is accurate
+  if (project.project.github_org !== parsed.org) {
+    project.project.github_org = parsed.org;
+    projectChanged = true;
+  }
+
   if (project.project.is_private !== repo.private) {
     project.project.is_private = repo.private;
     projectChanged = true;
@@ -149,11 +152,6 @@ export const getProject = async (
 
   if (project.project.generate_pages_site !== repo.has_pages) {
     project.project.generate_pages_site = repo.has_pages;
-    projectChanged = true;
-  }
-
-  if (project.project.github_org !== parsed.org) {
-    project.project.github_org = parsed.org;
     projectChanged = true;
   }
 

--- a/src/backend/projectHelpers.ts
+++ b/src/backend/projectHelpers.ts
@@ -21,6 +21,18 @@ import { initFs } from '@lib/memfs/index.ts';
 import type { IFs } from 'memfs';
 import type { RepositoryInvitation } from '@ty/github.ts';
 
+export const parseURL = (url: string) => {
+  const splitStart = url.split('https://github.com/');
+  const split = splitStart[1].split('/');
+  const org = split[0];
+  const repo = split[1];
+
+  return {
+    org,
+    repo,
+  };
+};
+
 export const getOrgs = async (
   userInfo: UserInfo
 ): Promise<GitHubOrganization[]> => {
@@ -115,9 +127,13 @@ export const getProject = async (
 
   const project: ProjectData = JSON.parse(proj as string);
 
+  const parsed = parseURL(htmlUrl);
+
+  console.log(parsed);
+
   const respRepo = await getRepo(
     userInfo.token,
-    project.project.github_org,
+    parsed.org,
     project.project.slug
   );
 
@@ -133,6 +149,11 @@ export const getProject = async (
 
   if (project.project.generate_pages_site !== repo.has_pages) {
     project.project.generate_pages_site = repo.has_pages;
+    projectChanged = true;
+  }
+
+  if (project.project.github_org !== parsed.org) {
+    project.project.github_org = parsed.org;
     projectChanged = true;
   }
 

--- a/src/lib/GitHub/index.ts
+++ b/src/lib/GitHub/index.ts
@@ -423,3 +423,22 @@ export const signOut = async (token: string): Promise<Response> => {
     }
   );
 };
+
+export const activateWorkflow = async (
+  token: string,
+  org: string,
+  repo: string,
+  workflowName: string
+): Promise<Response> => {
+  return await fetch(
+    `https://api.github.com/repos/${org}/${repo}/actions/workflows/${workflowName}/enable`,
+    {
+      method: 'PUT',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+};


### PR DESCRIPTION
# Summary

- Addresses https://github.com/AVAnnotate/admin-client/issues/291

This fixes the `project.json` reference to the old organization/account.