### PR TITLE
HTML Export

### DIFF
--- a/src/lib/events/export.ts
+++ b/src/lib/events/export.ts
@@ -1,4 +1,4 @@
-import { serializeToPlainText, serialize } from '@lib/slate/index.tsx';
+import { serializeToPlainHTML, serialize } from '@lib/slate/index.tsx';
 import type { AnnotationEntry, Event } from '@ty/Types.ts';
 import { formatTimestamp } from './index.ts';
 import ReactDOMServer from 'react-dom/server';
@@ -8,8 +8,14 @@ import type { Node } from 'slate';
 // (see https://stackoverflow.com/a/17808731)
 const formatField = (str: string) => `"${str.replaceAll('"', '""')}"`;
 
-const serializeRichText = (nodes: Node[]) =>
-  ReactDOMServer.renderToString(serialize(nodes));
+const serializeRichText = (nodes: Node[]) => {
+  let str = ReactDOMServer.renderToString(serializeToPlainHTML(nodes));
+
+  str = str.replace('<div>', '');
+  str = str.replace('</div>', '');
+  str = str.replace('<span>', '');
+  return str.replace('</span>', '');
+};
 
 export const exportAnnotations = (annos: AnnotationEntry[], event: Event) => {
   let str = 'Start Time,End Time,Annotation,Tags (vertical bar separated)\n';
@@ -26,7 +32,7 @@ export const exportAnnotations = (annos: AnnotationEntry[], event: Event) => {
         : Number.isNaN(anno.end_time)
         ? ''
         : formatTimestamp(Math.round(anno.end_time), false),
-      anno.annotation ? serializeToPlainText(anno.annotation) : '',
+      anno.annotation ? serializeRichText(anno.annotation) : '',
       anno.tags.map((t) => t.tag).join('|') || '',
     ];
 
@@ -54,7 +60,7 @@ export const exportEvents = (projectName: string, events: Event[]) => {
         event.audiovisual_files[uuid].label,
         event.audiovisual_files[uuid].file_url,
         event.citation || '',
-        event.description ? serializeToPlainText(event.description) : '',
+        event.description ? serializeRichText(event.description) : '',
       ];
 
       str += fields.map(formatField).join(',');

--- a/src/lib/slate/index.tsx
+++ b/src/lib/slate/index.tsx
@@ -258,6 +258,117 @@ export const emptyParagraph: SlateElement[] = [
   },
 ];
 
+export const LeafPlain = ({ attributes, children, leaf }: any) => {
+  if (leaf.bold) {
+    children = <b>{children}</b>;
+  }
+
+  if (leaf.code) {
+    children = <code>{children}</code>;
+  }
+
+  if (leaf.italic) {
+    children = <i>{children}</i>;
+  }
+
+  if (leaf.underline) {
+    children = <u>{children}</u>;
+  }
+
+  if (leaf.strikethrough) {
+    children = <s>{children}</s>;
+  }
+
+  if (leaf.highlight) {
+    children = (
+      <span style={{ backgroundColor: leaf.highlight }}>{children}</span>
+    );
+  }
+
+  if (leaf.color) {
+    children = <span style={{ color: leaf.color }}>{children}</span>;
+  }
+
+  if (leaf.link) {
+    children = <a href={leaf.link}>{children}</a>;
+  }
+
+  return children;
+};
+
+export const ElementPlain = ({
+  attributes,
+  children,
+  element,
+  project,
+  i18n,
+}: any) => {
+  const { t } = i18n;
+
+  switch (element.type) {
+    case 'link':
+      return <a href={element.url}>{children}</a>;
+    case 'block-quote':
+      return <blockquote>{children}</blockquote>;
+    case 'bulleted-list':
+      return <ul>{children}</ul>;
+    case 'heading-one':
+      return <h1>{children}</h1>;
+    case 'heading-two':
+      return <h2>{children}</h2>;
+    case 'line-break':
+      return <br />;
+    case 'list-item':
+      return <li>{children}</li>;
+    case 'numbered-list':
+      return <ol>{children}</ol>;
+    case 'image':
+      return children.length > 0 ? (
+        <div>
+          <img src={element.url} alt='Embedded image' />
+          {children}
+        </div>
+      ) : (
+        <img src={element.url} alt='Embedded image' />
+      );
+    case 'paragraph':
+      return <p>{children}</p>;
+    default:
+      return <p>children</p>;
+  }
+};
+
+export const serializeToPlainHTML = (nodes: Node[]) => {
+  const i18n = getTranslationsFromUrl(window.location.href, 'pages');
+
+  return nodes.map((node, idx) => {
+    if (Text.isText(node)) {
+      return (
+        <LeafPlain leaf={node} key={node.text}>
+          {node.text}
+        </LeafPlain>
+      );
+    }
+
+    if (node.children) {
+      const children = node.children.map((node) => serialize([node]));
+      return (
+        <LeafPlain leaf={node} key={idx}>
+          <ElementPlain element={node} i18n={i18n}>
+            {children}
+          </ElementPlain>
+        </LeafPlain>
+      );
+    } else {
+      return (
+        <LeafPlain leaf={node} key={idx}>
+          <ElementPlain element={node} i18n={i18n} />
+        </LeafPlain>
+      );
+    }
+  });
+};
+
 export const serializeToPlainText = (nodes: Node[]) => {
   return nodes.map((n) => Node.string(n)).join('\n');
 };


### PR DESCRIPTION
# Summary

Attempts to cleanup the HTML export via CSV by removing some of the extra HTML added by Slate JS.  Pretty hacky...

- Addresses https://github.com/AVAnnotate/admin-client/issues/316