### PR TITLE
Reset image dialog on re-open

### DIFF
--- a/src/components/Formic/SlateInput/FormattingComponents.tsx
+++ b/src/components/Formic/SlateInput/FormattingComponents.tsx
@@ -250,6 +250,8 @@ export const ImageButton = (props: ImageDialogProps) => {
               role='button'
               onClick={() => {
                 submit();
+                setUrl(undefined);
+                setCaption(undefined);
                 props.onClose && props.onClose();
               }}
             >


### PR DESCRIPTION
# Summary

- This addresses the issue raised in [this conversation](https://github.com/orgs/AVAnnotate/discussions/32)