### PR TITLE
Fix incorrect type value in rich text event embed modal when editing

### DIFF
--- a/src/components/InsertEventButton/SingleEventModal.tsx
+++ b/src/components/InsertEventButton/SingleEventModal.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import type { Includes, SlateEventNodeData } from '../../types/slate.ts';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ClipInterface,
   DurationInterface,
@@ -38,7 +38,6 @@ export const SingleEventModal: React.FC<SingleEventModalProps> = (props) => {
     props.start || props.end ? 'clip' : 'full'
   );
   const [file, setFile] = useState(props.file || undefined);
-  const [type, setType] = useState<'Audio' | 'Video' | undefined>();
   const [includes, setIncludes] = useState<Includes[]>(
     props.includes || ['media', 'annotations', 'label', 'description']
   );
@@ -52,16 +51,6 @@ export const SingleEventModal: React.FC<SingleEventModalProps> = (props) => {
       return null;
     }
   }, [eventUuid]);
-
-  useEffect(() => {
-    if (file && eventUuid) {
-      const type =
-        props.project.events[eventUuid as string].audiovisual_files[file]
-          .file_type;
-
-      setType(type);
-    }
-  }, [file, eventUuid]);
 
   const { t } = props.i18n;
 
@@ -137,7 +126,6 @@ export const SingleEventModal: React.FC<SingleEventModalProps> = (props) => {
                   start,
                   end,
                   file,
-                  type,
                 })
               }
             >


### PR DESCRIPTION
# Summary

The embedded event in #387 was disappearing because the edit modal was sending the `type` of the AV file to the `type` field on the node object, which is actually where Slate stores the element type. Slate relies on the `type` field to determine how to display the node, so getting an unrecognized value made the node disappear.

It doesn't look like we need to track the file type in the Slate node at all, because the project client gets that info directly by looking up the AV file in the content directory. This PR removes everything related to file type logic from `SingleEventModal`. 