### PR TITLE
Fix perpetual linkage

### DIFF
--- a/src/components/Formic/SlateInput/FormattingComponents.tsx
+++ b/src/components/Formic/SlateInput/FormattingComponents.tsx
@@ -7,6 +7,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import type { AVAEditor, ImageData, ImageSize } from '@ty/slate.ts';
 import type { Translations } from '@ty/Types.ts';
 import { ToolbarTooltip } from './ToolbarTooltip.tsx';
+import { Editor } from 'slate';
 
 export const HighlightColorButton = (props: SlateButtonProps) => {
   const editor = useSlate();
@@ -87,6 +88,8 @@ export const LinkButton = (props: LinkDialogProps) => {
     setOpen(false);
   };
 
+  const isActive = Editor.marks(editor)?.link;
+
   return (
     <Dialog.Root open={open}>
       <Dialog.Trigger asChild>
@@ -96,10 +99,16 @@ export const LinkButton = (props: LinkDialogProps) => {
         >
           <Button
             className={`link-button unstyled ${
-              highlightedText ? '' : 'disabled-link-button'
+              isActive ? 'activated-link-button' : ''
             }`}
-            disabled={!highlightedText}
-            onClick={() => setOpen(true)}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              if (isActive) {
+                Editor.removeMark(editor, 'link');
+              } else {
+                setOpen(true);
+              }
+            }}
             type='button'
           >
             <props.icon />

--- a/src/components/Formic/SlateInput/FormattingComponents.tsx
+++ b/src/components/Formic/SlateInput/FormattingComponents.tsx
@@ -88,6 +88,7 @@ export const LinkButton = (props: LinkDialogProps) => {
     setOpen(false);
   };
 
+  // @ts-expect-error
   const isActive = Editor.marks(editor)?.link;
 
   return (

--- a/src/components/Formic/SlateInput/SlateInput.css
+++ b/src/components/Formic/SlateInput/SlateInput.css
@@ -165,8 +165,8 @@
   border-radius: 4px;
 }
 
-.slate-form .disabled-link-button svg {
-  color: var(--gray-500);
+.slate-form .activated-link-button svg {
+  color: var(--primary);
 }
 
 .slate-form .disabled svg {


### PR DESCRIPTION
# Summary

This PR fixes the issue described by #388 by updating the link button in the toolbar to function as a toggle.

When you click the button when you're not inserting a link, it opens the modal as before. While inserting a link, the button is blue. You can click the blue link button to disable the link state and go back to normal. This makes it consistent with how italics/bold/etc work.