### PR TITLE
Fixing page crash from annotations on deleted files

### DIFF
--- a/src/apps/AnnotationImport/AnnotationImport.tsx
+++ b/src/apps/AnnotationImport/AnnotationImport.tsx
@@ -95,16 +95,21 @@ export const AnnotationImportForm: React.FC<Props> = (props) => {
     () =>
       Object.keys(props.project.annotations)
         .filter(
-          (uuid) => props.project.annotations[uuid].event_id === props.eventUuid
+          (uuid) =>
+            props.project.annotations[uuid].event_id === props.eventUuid &&
+            props.project.events[props.project?.annotations[uuid]?.event_id]
+              ?.audiovisual_files[props.project?.annotations[uuid]?.source_id] //filter out annotations from deleted files
         )
-        .map((uuid) => ({
-          label: `${
-            props.project.events[props.project.annotations[uuid].event_id]
-              .audiovisual_files[props.project.annotations[uuid].source_id]
-              .label
-          } - ${props.project.annotations[uuid].set}`,
-          value: uuid,
-        })),
+        .map((uuid) => {
+          return {
+            label: `${
+              props.project.events[props.project.annotations[uuid].event_id]
+                .audiovisual_files[props.project.annotations[uuid].source_id]
+                ?.label
+            } - ${props.project.annotations[uuid].set}`,
+            value: uuid,
+          };
+        }),
     []
   );
 


### PR DESCRIPTION
### In this PR
Filters out annotations associated with AV files that aren't listed on the specified event (and therefore have no metadata, label etc) from the dropdown on the import annotations page. This fixes a bug where the import page crashes in the case when there are annotations still listened in `project.annotations[eventUUID]` that have a `source_id` that isn't part of the event data.

Addresses part of https://github.com/orgs/AVAnnotate/discussions/23

### Notes and questions
Should the project be able to get into this state at all? It seems to me that when an AV file is deleted from an event we're not currently deleting any annotations that had been attached to it, but I can imagine that that's on purpose so that users don't accidentally erase data they didn't mean to? Hence for now I've just done a minimal fix that stops the import page from crashing without actually changing what we're saving in the project data, but I'm open to other opinions on how we should be handling annotations from deleted files.