### PR TITLE
Changing text for empty filtered annotations

### DIFF
--- a/src/apps/EventDetail/AnnotationTable.tsx
+++ b/src/apps/EventDetail/AnnotationTable.tsx
@@ -108,6 +108,7 @@ interface AnnotationTableProps {
   hideHeader?: boolean;
   project: ProjectData;
   projectSlug: string;
+  search?: boolean;
   setDeleteAnnoUuid: (uuid: string) => void;
   setEditAnnoUuid: (uuid: string) => void;
   setAnnoPosition: (pos: number) => void;
@@ -145,10 +146,16 @@ const AnnotationTable: React.FC<AnnotationTableProps> = (props) => {
     return () => resizeObserver.disconnect();
   }, []);
 
+  const emptyNoticeText = useMemo(() => {
+    return props.search
+      ? t['No search results found.']
+      : t['No annotations have been added.'];
+  }, [props.search]);
+
   const emptyNotice = useMemo(
     () => (
       <Table.Cell colSpan={4} className='empty-annos-note'>
-        <p>{t['No annotations have been added.']}</p>
+        <p>{emptyNoticeText}</p>
         <div className='empty-annos-buttons'>
           <Button
             className='primary'
@@ -167,7 +174,7 @@ const AnnotationTable: React.FC<AnnotationTableProps> = (props) => {
         </div>
       </Table.Cell>
     ),
-    []
+    [emptyNoticeText]
   );
 
   const containerRef = useRef(null);

--- a/src/apps/EventDetail/AvFile.tsx
+++ b/src/apps/EventDetail/AvFile.tsx
@@ -319,6 +319,7 @@ const AvFile: React.FC<Props> = (props) => {
           setShowAnnoCreateModal={setShowAnnoCreateModal}
           tagPosition={props.fileType === 'Video' ? 'below' : 'column'}
           hideHeader={props.fileType === 'Video'}
+          search={!!search}
         />
       </div>
       {props.fileType === 'Audio' && props.event.citation && (

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -37,6 +37,7 @@
   "associated annotations will also be deleted.": "associated annotations will also be deleted.",
   "AV File": "AV File",
   "No annotations have been added.": "No annotations have been added.",
+  "No search results found.": "No search results found.",
   "Analyze": "Analyze",
   "Manifest Analysis failed": "Manifest Analysis failed",
   "Analysis complete": "Analysis complete",


### PR DESCRIPTION
### In this PR
Addresses Issue #408 by changing the text displayed when there are no annotations to display and the search filter is non-empty, to avoid confusion: 
<img width="2084" height="688" alt="image" src="https://github.com/user-attachments/assets/ba8c5bdd-ee6b-4fdc-be79-f65d05d7ef48" />
