### PR TITLE
Ordering AV file tabs by `av_file_order` when relevant

### DIFF
--- a/src/apps/EventDetail/index.tsx
+++ b/src/apps/EventDetail/index.tsx
@@ -27,7 +27,8 @@ export const EventDetail: React.FC<EventDetailProps> = (props) => {
   const [showEventDeleteModal, setShowEventDeleteModal] = useState(false);
 
   const tabs = useMemo(() => {
-    const uuids = Object.keys(props.event.audiovisual_files);
+    const uuids =
+      props.event.av_file_order || Object.keys(props.event.audiovisual_files);
     const isSingleAvFile = uuids.length === 1;
 
     return uuids.map((uuid, index) => {


### PR DESCRIPTION
### In this PR
Addresses Issue #418 by checking whether `av_file_order` is defined in the event data when determining the order of the tabs.