### PR TITLE
Making autogenerated pages parentless

### DIFF
--- a/src/lib/pages/autogenerate.ts
+++ b/src/lib/pages/autogenerate.ts
@@ -25,7 +25,6 @@ export const autoGenerateEventPage = async (
     slug: slug,
     updated_at: new Date().toISOString(),
     updated_by: info!.profile.gitHubName || '',
-    parent: homePageId,
     autogenerate: {
       enabled: ev.auto_generate_web_page,
       type: 'event',


### PR DESCRIPTION
### In this PR
Updates the autogenerate page function to not assign the home page automatically as the parent, as per Issue #420 .