### PR TITLE
Fixing `AvFilePicker` value prop

### DIFF
--- a/src/components/SetModal/SetModal.tsx
+++ b/src/components/SetModal/SetModal.tsx
@@ -81,7 +81,7 @@ export const SetFormModal: React.FC<Props> = (props) => {
               </label>
               {useForCaptions && (
                 <label>
-                  {t['Tag Category for Speaker (optional)']}
+                  {t['Tag Category for .VTT voice tag (optional)']}
                   <AvFilePicker
                     options={props.speakerCategoryOptions || []}
                     value={speakerCategory || ''}

--- a/src/i18n/en/events.json
+++ b/src/i18n/en/events.json
@@ -70,7 +70,7 @@
   "Number of Annotations": "Number of Annotations",
   "Captions": "Captions",
   "Use for Captions": "Use for Captions",
-  "Tag Category for Speaker (optional)": "Tag Category for Speaker (optional)",
+  "Tag Category for .VTT voice tag (optional)": "Tag Category for .VTT voice tag (optional)",
   "Override Duration": "Override Duration",
   "Calculate Duration": "Calculate Duration",
   "No media is available.": "No media is available.",


### PR DESCRIPTION
### In this PR
Addresses Issue #422 by updating the `value` prop on the relevant dropdown menu to update correctly as the `speakerCategory` variable updates, rather than being statically set to the initial value.

Also updates the language in the modal to (hopefully) be clearer about the role of the selected category as the VTT voice tag, rather than appearing in the visible captions as a speaker label.