### PR TITLE
Fixing bug in deleting VTT files

### DIFF
--- a/src/pages/api/projects/[projectName]/events/[eventUuid]/index.ts
+++ b/src/pages/api/projects/[projectName]/events/[eventUuid]/index.ts
@@ -217,13 +217,20 @@ export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
 
   const repositoryURL = getRepositoryUrl(projectName);
 
-  const { readDir, readFile, commitAndPush, deleteFile, writeFile, context } =
-    await gitRepo({
-      fs: initFs(),
-      repositoryURL,
-      branch: 'main',
-      userInfo: info as UserInfo,
-    });
+  const {
+    readDir,
+    readFile,
+    commitAndPush,
+    deleteFile,
+    writeFile,
+    context,
+    exists,
+  } = await gitRepo({
+    fs: initFs(),
+    repositoryURL,
+    branch: 'main',
+    userInfo: info as UserInfo,
+  });
 
   const filepath = `/data/events/${eventUuid}.json`;
 
@@ -297,7 +304,11 @@ export const DELETE: APIRoute = async ({ cookies, params, redirect }) => {
   for (let key of Object.keys(event.audiovisual_files)) {
     const avFile = event.audiovisual_files[key];
     if (avFile.caption_set && avFile.caption_set.length > 0) {
-      deleteFile(`/data/vtt/${avFile.caption_set}.vtt`);
+      for (const set of avFile.caption_set) {
+        if (exists(`/data/vtt/${set.annotation_page_id}.vtt`)) {
+          await deleteFile(`/data/vtt/${set.annotation_page_id}.vtt`);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### In this PR
Fixes a bug that was preventing events from deleting successfully in the case that a caption set is specified for one of its AV files. (Previously it appears we were attempting to delete the file `/data/vtt/${AVFile.caption_set}.vtt` but `AVFile.caption_set` is an object, not a strong; this was causing the Netlify function to just freak out and return an error status.)