### PR TITLE
Improve GitHub API diagnostics for project creation failures

### DIFF
--- a/src/pages/api/projects/[projectName]/index.ts
+++ b/src/pages/api/projects/[projectName]/index.ts
@@ -24,6 +24,41 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { updateProjectLastUpdated } from '@lib/pages/index.ts';
 
+const logGitHubErrorResponse = async (
+  stage: string,
+  response: Response,
+  context?: Record<string, unknown>
+) => {
+  const requestId =
+    response.headers.get('x-github-request-id') ||
+    response.headers.get('x-request-id') ||
+    'unknown';
+  const rateLimitRemaining = response.headers.get('x-ratelimit-remaining');
+  const scope = response.headers.get('x-oauth-scopes');
+  const acceptedScope = response.headers.get('x-accepted-oauth-scopes');
+
+  let responseBody: unknown = null;
+  const rawBody = await response.text();
+  if (rawBody) {
+    try {
+      responseBody = JSON.parse(rawBody);
+    } catch {
+      responseBody = rawBody;
+    }
+  }
+
+  console.error(`[GitHub ${stage}] request failed`, {
+    status: response.status,
+    statusText: response.statusText,
+    requestId,
+    rateLimitRemaining,
+    scope,
+    acceptedScope,
+    responseBody,
+    ...context,
+  });
+};
+
 // Note: this POST route is the only /api/projects route that expects the
 // `projectName` param to be the bare name instead of the slug version that
 // combines org and name. All other /api/projects API routes expect the full slug.
@@ -81,13 +116,17 @@ export const POST: APIRoute = async ({
     );
 
     if (!resp.ok) {
-      console.error('Failed to create project repo: ', resp.statusText);
-      console.error('Body: ', body);
+      await logGitHubErrorResponse('repo-create-from-template', resp, {
+        gitHubOrg: body.gitHubOrg,
+        templateRepo: body.templateRepo,
+        projectName,
+        visibility: body.visibility,
+      });
       return new Response(
         JSON.stringify({
           avaError: '_repo_create_failed_',
         }),
-        { status: 500, statusText: resp.statusText }
+        { status: resp.status || 500, statusText: resp.statusText }
       );
     }
 
@@ -102,14 +141,16 @@ export const POST: APIRoute = async ({
       );
 
       if (!respPages.ok) {
-        console.error('Status: ', respPages.status);
-        console.error('Failed to enable GitHub pages: ', respPages.statusText);
+        await logGitHubErrorResponse('pages-enable', respPages, {
+          gitHubOrg: body.gitHubOrg,
+          projectName,
+        });
         return new Response(
           JSON.stringify({
             avaError: '_failed_pages_enable_',
           }),
           {
-            status: 500,
+            status: respPages.status || 500,
             statusText: respPages.statusText,
           }
         );
@@ -127,14 +168,16 @@ export const POST: APIRoute = async ({
     );
 
     if (!respTopics.ok) {
-      console.error('Status: ', respTopics.status);
-      console.error('Failed to add topic: ', respTopics.statusText);
+      await logGitHubErrorResponse('topics-replace', respTopics, {
+        gitHubOrg: body.gitHubOrg,
+        projectName,
+      });
       return new Response(
         JSON.stringify({
           avaError: '_failed_adding_topic_',
         }),
         {
-          status: 500,
+          status: respTopics.status || 500,
           statusText: respTopics.statusText,
         }
       );


### PR DESCRIPTION
### Motivation

- Creating repositories from the shared template was producing opaque 500 errors for enterprise-managed users, making it hard to diagnose whether the issue was token scope, enterprise policy, or template-generation failures. 
- We need richer server-side diagnostics (request ids, scopes, rate-limit info, and parsed response payloads) to correlate with GitHub support and to tell permission problems from true server errors.

### Description

- Add a reusable `logGitHubErrorResponse` helper in the project-creation API route (`src/pages/api/projects/[projectName]/index.ts`) that logs status, `x-github-request-id`/`x-request-id`, `x-ratelimit-remaining`, OAuth scopes, and a safely-parsed response body (JSON or text). 
- Use the helper for the critical failure points: `repo-create-from-template`, `pages-enable`, and `topics-replace`, so POST/PATCH failures emit actionable logs. 
- Return the upstream GitHub HTTP status (or fallback to 500) and preserve `statusText` for these failure responses instead of always coercing to 500. 
- The change makes it easier to trace enterprise-specific failures and shows where additional logging (for example in `src/lib/GitHub/index.ts` before `fetch`) would be helpful.

### Testing

- Ran `npm run build` (which runs `astro check && astro build`) and the build completed successfully with TypeScript warnings only. 
- Verified the modified file is type-checking as part of the build step and the server bundle was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69aef3acdc4c83289b3a21eff9bddd58)