### PR TITLE
Log GitHub template repository generation request

### DIFF
--- a/src/lib/GitHub/index.ts
+++ b/src/lib/GitHub/index.ts
@@ -161,21 +161,31 @@ export const createRepositoryFromTemplate = async (
     description: description,
     private: visibility !== 'public',
   };
+  const url = `https://api.github.com/repos/${
+    import.meta.env.GIT_REPO_ORG
+  }/${templateRepo}/generate`;
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  const requestOptions = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  };
 
-  return await fetch(
-    `https://api.github.com/repos/${
-      import.meta.env.GIT_REPO_ORG
-    }/${templateRepo}/generate`,
-    {
-      method: 'POST',
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      body: JSON.stringify(body),
-    }
-  );
+  console.info('Creating repository from template', {
+    url,
+    method: requestOptions.method,
+    body,
+    headers: {
+      ...headers,
+      Authorization: 'Bearer [redacted]',
+    },
+  });
+
+  return await fetch(url, requestOptions);
 };
 
 export const addRepositoryHomepage = async (


### PR DESCRIPTION
### Motivation
- Improve observability for repository creation from a template by extracting the request URL and options to local variables and emitting a sanitized log before the network call.
- Ensure sensitive credentials are not exposed in logs by redacting the `Authorization` token.

### Description
- Refactored `createRepositoryFromTemplate` to assign the generated GitHub API `url` to a local variable instead of building it inline in the `fetch` call.
- Moved request headers into a local `headers` object and assembled `requestOptions` containing `method`, `headers`, and `body`.
- Added a pre-fetch `console.info` call that logs the `url`, `method`, `body`, and `headers` with `Authorization` set to `'Bearer [redacted]'`.
- Updated the `fetch` invocation to use the local `url` and `requestOptions` variables.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43f32fbc008328a57cc4d03317c398)