### PR TITLE
Add GitHub enterprise/internal visibility support and switch project API to `is_private`

### DIFF
--- a/src/apps/NewProject/NewProject.tsx
+++ b/src/apps/NewProject/NewProject.tsx
@@ -44,7 +44,7 @@ export const NewProject = (props: NewProjectProps) => {
       additionalUsers: project.additional_users.map((u) => u.login_name),
       language: project.language,
       autoPopulateHomePage: project.auto_populate_home_page,
-      visibility: project.is_private ? 'private' : 'public',
+      is_private: !!project.is_private,
       generate_pages_site: !!project.generate_pages_site,
       tags: project.tags,
     };

--- a/src/lib/GitHub/config.ts
+++ b/src/lib/GitHub/config.ts
@@ -1,0 +1,24 @@
+export type RepoVisibility = 'private' | 'public' | 'internal';
+
+export const getEnterpriseGitHubOrgs = (): string[] => {
+  const enterpriseOrgs =
+    import.meta.env.PUBLIC_GITHUB_ENTERPRISE_ORGS ||
+    import.meta.env.GITHUB_ENTERPRISE_ORGS ||
+    '';
+
+  return enterpriseOrgs
+    .split(',')
+    .map((org: string) => org.trim().toLowerCase())
+    .filter(Boolean);
+};
+
+export const isEnterpriseGitHubOrg = (org: string): boolean =>
+  getEnterpriseGitHubOrgs().includes(org.trim().toLowerCase());
+
+export const getTemplateOwnerForDestinationOrg = (org: string): string => {
+  if (isEnterpriseGitHubOrg(org) && import.meta.env.GIT_REPO_ORG_ENTERPRISE) {
+    return import.meta.env.GIT_REPO_ORG_ENTERPRISE;
+  }
+
+  return import.meta.env.GIT_REPO_ORG;
+};

--- a/src/lib/GitHub/index.ts
+++ b/src/lib/GitHub/index.ts
@@ -1,3 +1,17 @@
+import {
+  getEnterpriseGitHubOrgs,
+  getTemplateOwnerForDestinationOrg,
+  isEnterpriseGitHubOrg,
+} from './config.ts';
+import type { RepoVisibility } from './config.ts';
+
+export {
+  getEnterpriseGitHubOrgs,
+  getTemplateOwnerForDestinationOrg,
+  isEnterpriseGitHubOrg,
+};
+export type { RepoVisibility } from './config.ts';
+
 export const paginate = async (url: string, token: string) => {
   let results: any[] = [];
 
@@ -153,7 +167,7 @@ export const createRepositoryFromTemplate = async (
   token: string,
   newRepoName: string,
   description: string,
-  visibility?: 'private' | 'public' // Defaults to private
+  visibility?: RepoVisibility // Defaults to private
 ): Promise<Response> => {
   const body = {
     owner: org,
@@ -161,21 +175,21 @@ export const createRepositoryFromTemplate = async (
     description: description,
     private: visibility !== 'public',
   };
+  const templateOwner = getTemplateOwnerForDestinationOrg(org);
+  const url = `https://api.github.com/repos/${templateOwner}/${templateRepo}/generate`;
 
-  return await fetch(
-    `https://api.github.com/repos/${
-      import.meta.env.GIT_REPO_ORG
-    }/${templateRepo}/generate`,
-    {
-      method: 'POST',
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      body: JSON.stringify(body),
-    }
-  );
+  console.info('GitHub template generation URL:', url);
+  console.info('GitHub template generation payload:', body);
+
+  return await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify(body),
+  });
 };
 
 export const addRepositoryHomepage = async (
@@ -372,8 +386,13 @@ export const changeRepoVisibility = async (
   token: string,
   org: string,
   slug: string,
-  isPrivate: boolean
+  visibility: boolean | RepoVisibility
 ): Promise<Response> => {
+  const body =
+    typeof visibility === 'boolean'
+      ? { private: visibility }
+      : { visibility: visibility };
+
   return await fetch(`https://api.github.com/repos/${org}/${slug}`, {
     method: 'PATCH',
     headers: {
@@ -381,9 +400,7 @@ export const changeRepoVisibility = async (
       Authorization: `Bearer ${token}`,
       'X-GitHub-Api-Version': '2022-11-28',
     },
-    body: JSON.stringify({
-      private: isPrivate,
-    }),
+    body: JSON.stringify(body),
   });
 };
 

--- a/src/pages/api/projects/[projectName]/index.ts
+++ b/src/pages/api/projects/[projectName]/index.ts
@@ -7,6 +7,7 @@ import {
   changeRepoVisibility,
   disablePages,
   removeRepositoryHomepage,
+  isEnterpriseGitHubOrg,
 } from '@lib/GitHub/index.ts';
 import type { APIRoute } from 'astro';
 import type { apiProjectPut, apiProjectsProjectNamePost } from '@ty/api.ts';
@@ -23,6 +24,19 @@ import {
 } from '@backend/projectHelpers.ts';
 import { v4 as uuidv4 } from 'uuid';
 import { updateProjectLastUpdated } from '@lib/pages/index.ts';
+
+
+const logGitHubFailure = async (stage: string, response: Response) => {
+  const requestId = response.headers.get('x-github-request-id');
+  const responseBody = await response.clone().text();
+
+  console.error(`GitHub ${stage} failed`, {
+    status: response.status,
+    statusText: response.statusText,
+    requestId,
+    responseBody,
+  });
+};
 
 // Note: this POST route is the only /api/projects route that expects the
 // `projectName` param to be the bare name instead of the slug version that
@@ -51,6 +65,12 @@ export const POST: APIRoute = async ({
 
     const body: apiProjectsProjectNamePost = await request.json();
 
+    const repoVisibility = body.is_private
+      ? 'private'
+      : isEnterpriseGitHubOrg(body.gitHubOrg)
+        ? 'internal'
+        : 'public';
+
     // First see if we can create this repo
     const check: Response = await getRepo(
       token?.value as string,
@@ -77,10 +97,11 @@ export const POST: APIRoute = async ({
       token?.value as string,
       projectName as string,
       body.title,
-      body.visibility
+      repoVisibility
     );
 
     if (!resp.ok) {
+      await logGitHubFailure('repo-template-generate', resp);
       console.error('Failed to create project repo: ', resp.statusText);
       console.error('Body: ', body);
       return new Response(
@@ -93,6 +114,28 @@ export const POST: APIRoute = async ({
 
     const repo: FullRepository = await resp.json();
 
+    if (repoVisibility === 'internal') {
+      const visibilityResp = await changeRepoVisibility(
+        token?.value as string,
+        body.gitHubOrg,
+        projectName as string,
+        'internal'
+      );
+
+      if (!visibilityResp.ok) {
+        await logGitHubFailure('repo-visibility-internal', visibilityResp);
+        return new Response(
+          JSON.stringify({
+            avaError: '_repo_create_failed_',
+          }),
+          {
+            status: 500,
+            statusText: visibilityResp.statusText,
+          }
+        );
+      }
+    }
+
     if (body.generate_pages_site) {
       // Enable pages
       const respPages: Response = await enablePages(
@@ -102,6 +145,7 @@ export const POST: APIRoute = async ({
       );
 
       if (!respPages.ok) {
+        await logGitHubFailure('pages-enable', respPages);
         console.error('Status: ', respPages.status);
         console.error('Failed to enable GitHub pages: ', respPages.statusText);
         return new Response(
@@ -187,7 +231,8 @@ export const POST: APIRoute = async ({
       users: collabs,
       project: {
         github_org: body.gitHubOrg,
-        is_private: body.visibility === 'private',
+        // Internal GitHub repos are represented as non-private in project metadata.
+        is_private: body.is_private,
         title: body.title,
         description: body.description,
         language: body.language,
@@ -425,6 +470,7 @@ export const PUT: APIRoute = async ({ cookies, params, request, redirect }) => {
       );
 
       if (!respPages.ok) {
+        await logGitHubFailure('pages-enable', respPages);
         console.error('Status: ', respPages.status);
         console.error('Failed to enable GitHub pages: ', respPages.statusText);
         return new Response(

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -32,7 +32,7 @@ export type apiAnnotationSetPost = {
 export type apiProjectsProjectNamePost = {
   templateRepo: string;
   description: string;
-  visibility: 'private' | 'public';
+  is_private: boolean;
   generate_pages_site: boolean;
   title: string;
   slug: string;


### PR DESCRIPTION
### Motivation
- Allow creating repositories with GitHub's `internal` visibility for enterprise organizations and centralize GitHub org/template owner config.
- Normalize the project creation API to use a boolean `is_private` flag instead of a `visibility` string.

### Description
- Introduced `src/lib/GitHub/config.ts` with `getEnterpriseGitHubOrgs`, `isEnterpriseGitHubOrg`, and `getTemplateOwnerForDestinationOrg` and exported types/helpers from `src/lib/GitHub/index.ts`.
- Updated `createRepositoryFromTemplate` to select the correct template owner via `getTemplateOwnerForDestinationOrg`, accept the new `RepoVisibility` type, and log the template generation URL/payload.
- Broadened `changeRepoVisibility` to accept either a boolean or a visibility string and send the appropriate request body for `private` vs `visibility` updates.
- Changed the frontend and API contract to use `is_private: boolean` (`src/types/api.ts` and `src/apps/NewProject/NewProject.tsx`) and compute the actual GitHub visibility server-side as `private`, `public`, or `internal` based on `is_private` and whether the destination org is an enterprise org.
- In the projects API handler (`src/pages/api/projects/[projectName]/index.ts`) added `logGitHubFailure` for richer GitHub error logging, pass the computed visibility to template generation, and set repo visibility to `internal` post-creation when needed; also used `is_private` in project metadata and added extra logging on pages enable failures.

### Testing
- Ran the TypeScript build (`yarn build`) to validate types and compilation, which succeeded.
- Ran the test suite (`yarn test`) and linters (`yarn lint`), both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ff0f1b4483289a2d71ccb82bcfcc)